### PR TITLE
[FEATURE]: add AXSL shader language compiler pipeline :sparkles:

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,3 +1,4 @@
 BasedOnStyle: LLVM
 IndentWidth: 2
+IndentCaseLabels: true
 UseTab: Never

--- a/axslc/CMakeLists.txt
+++ b/axslc/CMakeLists.txt
@@ -1,0 +1,17 @@
+cmake_minimum_required(VERSION 3.21)
+project(axslc CXX)
+
+set(CMAKE_CXX_STANDARD 20)
+
+set(SHADER_LANG_DIR "${CMAKE_SOURCE_DIR}/../src/modules/renderer/shader-lang")
+set(CMAKE_EXPORT_COMPILE_COMMANDS TRUE)
+
+file(GLOB_RECURSE SHADER_LANG_SRC
+  "${SHADER_LANG_DIR}/*.cpp"
+  "${SHADER_LANG_DIR}/emitters/*.cpp")
+list(FILTER SHADER_LANG_SRC EXCLUDE REGEX "\\.test\\.cpp$")
+
+add_executable(axslc main.cpp args.cpp ${SHADER_LANG_SRC})
+
+target_include_directories(axslc PRIVATE
+  "${CMAKE_SOURCE_DIR}/../src/modules/renderer")

--- a/axslc/args.cpp
+++ b/axslc/args.cpp
@@ -1,0 +1,99 @@
+#include "args.hpp"
+#include <iostream>
+#include <unordered_map>
+
+std::vector<Token> tokenize(int argc, char **argv) {
+  std::vector<Token> tokens;
+  tokens.reserve(argc - 1);
+  for (int i = 1; i < argc; ++i) {
+    std::string_view sv = argv[i];
+    Token::Kind kind = (sv.size() > 1 && sv[0] == '-') ? Token::Kind::Flag
+                                                       : Token::Kind::Value;
+    tokens.push_back({kind, sv});
+  }
+  return tokens;
+}
+
+bool parse(const std::vector<Token> &tokens, Options &opts) {
+  enum class Flag { Help, Version, Verbose, Output, IncludePath };
+
+  const std::unordered_map<std::string_view, Flag> flag_aliases = {
+      {"-h", Flag::Help},
+      {"--help", Flag::Help},
+      {"--version", Flag::Version},
+      {"-v", Flag::Verbose},
+      {"--verbose", Flag::Verbose},
+      {"-o", Flag::Output},
+      {"--output", Flag::Output},
+      {"-I", Flag::IncludePath},
+      {"--include-path", Flag::IncludePath},
+  };
+
+  for (size_t i = 0; i < tokens.size(); ++i) {
+    const Token &token = tokens[i];
+
+    if (token.kind == Token::Kind::Value) {
+      if (!opts.input_file.empty()) {
+        std::cerr << "error: multiple input files specified\n";
+        return false;
+      }
+      opts.input_file = token.text;
+      continue;
+    }
+
+    auto it = flag_aliases.find(token.text);
+    if (it == flag_aliases.end()) {
+      std::cerr << "error: unknown option '" << token.text << "'\n";
+      return false;
+    }
+
+    auto require_next = [&](std::string &destination) -> bool {
+      if (i + 1 >= tokens.size() || tokens[i + 1].kind != Token::Kind::Value) {
+        std::cerr << "error: " << token.text << " requires an argument\n";
+        return false;
+      }
+      destination = tokens[++i].text;
+      return true;
+    };
+
+    switch (it->second) {
+    case Flag::Help: {
+      opts.help = true;
+      return true;
+    }
+    case Flag::Version: {
+      opts.version = true;
+      return true;
+    }
+    case Flag::Verbose: {
+      opts.verbose = true;
+      break;
+    }
+    case Flag::Output: {
+      if (!require_next(opts.output_dir)) {
+        return false;
+      }
+
+      break;
+    }
+    case Flag::IncludePath: {
+      if (!require_next(opts.include_path)) {
+        return false;
+      }
+
+      break;
+    }
+    }
+  }
+
+  if (!opts.help && !opts.version && opts.input_file.empty()) {
+    std::cerr << "error: no input file specified\n";
+    return false;
+  }
+
+  return true;
+}
+
+bool parse_args(int argc, char **argv, Options &opts) {
+  return parse(tokenize(argc, argv), opts);
+}

--- a/axslc/args.hpp
+++ b/axslc/args.hpp
@@ -1,0 +1,23 @@
+#pragma once
+#include <string>
+#include <string_view>
+#include <vector>
+
+struct Options {
+  std::string input_file;
+  std::string output_dir;
+  std::string include_path;
+  bool verbose = false;
+  bool help = false;
+  bool version = false;
+};
+
+struct Token {
+  enum class Kind { Flag, Value };
+  Kind kind;
+  std::string_view text;
+};
+
+std::vector<Token> tokenize(int argc, char **argv);
+bool parse(const std::vector<Token> &tokens, Options &opts);
+bool parse_args(int argc, char **argv, Options &opts);

--- a/axslc/args.test.cpp
+++ b/axslc/args.test.cpp
@@ -1,0 +1,195 @@
+#include "args.hpp"
+#include <gtest/gtest.h>
+#include <sstream>
+
+struct FakeArgv {
+  std::vector<std::string> storage;
+  std::vector<char *> ptrs;
+
+  FakeArgv(std::initializer_list<const char *> args) {
+    storage.emplace_back("axslc");
+    for (const char *a : args)
+      storage.emplace_back(a);
+    for (auto &s : storage)
+      ptrs.push_back(s.data());
+  }
+
+  int argc() const { return static_cast<int>(ptrs.size()); }
+  char **argv() { return ptrs.data(); }
+};
+
+TEST(Tokenize, EmptyArgv) {
+  FakeArgv fake_argument{};
+  auto tokens = tokenize(fake_argument.argc(), fake_argument.argv());
+  EXPECT_TRUE(tokens.empty());
+}
+
+TEST(Tokenize, SingleValue) {
+  FakeArgv fake_argument{"shader.axsl"};
+  auto tokens = tokenize(fake_argument.argc(), fake_argument.argv());
+  ASSERT_EQ(tokens.size(), 1u);
+  EXPECT_EQ(tokens[0].kind, Token::Kind::Value);
+  EXPECT_EQ(tokens[0].text, "shader.axsl");
+}
+
+TEST(Tokenize, SingleFlag) {
+  FakeArgv fake_argument{"--verbose"};
+  auto tokens = tokenize(fake_argument.argc(), fake_argument.argv());
+  ASSERT_EQ(tokens.size(), 1u);
+  EXPECT_EQ(tokens[0].kind, Token::Kind::Flag);
+  EXPECT_EQ(tokens[0].text, "--verbose");
+}
+
+TEST(Tokenize, ShortFlag) {
+  FakeArgv fake_argument{"-v"};
+  auto tokens = tokenize(fake_argument.argc(), fake_argument.argv());
+  ASSERT_EQ(tokens.size(), 1u);
+  EXPECT_EQ(tokens[0].kind, Token::Kind::Flag);
+}
+
+TEST(Tokenize, MixedFlagsAndValues) {
+  FakeArgv fake_argument{"-v", "-o", "build/", "shader.axsl"};
+  auto tokens = tokenize(fake_argument.argc(), fake_argument.argv());
+  ASSERT_EQ(tokens.size(), 4u);
+  EXPECT_EQ(tokens[0].kind, Token::Kind::Flag);
+  EXPECT_EQ(tokens[1].kind, Token::Kind::Flag);
+  EXPECT_EQ(tokens[2].kind, Token::Kind::Value);
+  EXPECT_EQ(tokens[3].kind, Token::Kind::Value);
+}
+
+TEST(Tokenize, SingleDashIsValue) {
+  FakeArgv fake_argument{"-"};
+  auto tokens = tokenize(fake_argument.argc(), fake_argument.argv());
+  ASSERT_EQ(tokens.size(), 1u);
+  EXPECT_EQ(tokens[0].kind, Token::Kind::Value);
+}
+
+static std::vector<Token>
+make_tokens(std::initializer_list<const char *> args) {
+  FakeArgv fake_argument(args);
+  return tokenize(fake_argument.argc(), fake_argument.argv());
+}
+
+TEST(Parse, HelpShort) {
+  Options opts;
+  EXPECT_TRUE(parse(make_tokens({"-h"}), opts));
+  EXPECT_TRUE(opts.help);
+}
+
+TEST(Parse, HelpLong) {
+  Options opts;
+  EXPECT_TRUE(parse(make_tokens({"--help"}), opts));
+  EXPECT_TRUE(opts.help);
+}
+
+TEST(Parse, Version) {
+  Options opts;
+  EXPECT_TRUE(parse(make_tokens({"--version"}), opts));
+  EXPECT_TRUE(opts.version);
+}
+
+TEST(Parse, VerboseShort) {
+  Options opts;
+  EXPECT_TRUE(parse(make_tokens({"-v", "shader.axsl"}), opts));
+  EXPECT_TRUE(opts.verbose);
+  EXPECT_EQ(opts.input_file, "shader.axsl");
+}
+
+TEST(Parse, VerboseLong) {
+  Options opts;
+  EXPECT_TRUE(parse(make_tokens({"--verbose", "shader.axsl"}), opts));
+  EXPECT_TRUE(opts.verbose);
+}
+
+TEST(Parse, OutputShort) {
+  Options opts;
+  EXPECT_TRUE(parse(make_tokens({"-o", "build/", "shader.axsl"}), opts));
+  EXPECT_EQ(opts.output_dir, "build/");
+  EXPECT_EQ(opts.input_file, "shader.axsl");
+}
+
+TEST(Parse, OutputLong) {
+  Options opts;
+  EXPECT_TRUE(parse(make_tokens({"--output", "out/", "shader.axsl"}), opts));
+  EXPECT_EQ(opts.output_dir, "out/");
+}
+
+TEST(Parse, IncludePathShort) {
+  Options opts;
+  EXPECT_TRUE(parse(make_tokens({"-I", "./shaders", "shader.axsl"}), opts));
+  EXPECT_EQ(opts.include_path, "./shaders");
+}
+
+TEST(Parse, IncludePathLong) {
+  Options opts;
+  EXPECT_TRUE(
+      parse(make_tokens({"--include-path", "./inc", "shader.axsl"}), opts));
+  EXPECT_EQ(opts.include_path, "./inc");
+}
+
+TEST(Parse, AllOptionsTogether) {
+  Options opts;
+  EXPECT_TRUE(parse(
+      make_tokens({"-v", "-o", "out/", "-I", "inc/", "shader.axsl"}), opts));
+  EXPECT_TRUE(opts.verbose);
+  EXPECT_EQ(opts.output_dir, "out/");
+  EXPECT_EQ(opts.include_path, "inc/");
+  EXPECT_EQ(opts.input_file, "shader.axsl");
+}
+
+TEST(Parse, InputFileBeforeFlags) {
+  Options opts;
+  EXPECT_TRUE(parse(make_tokens({"shader.axsl", "-v"}), opts));
+  EXPECT_EQ(opts.input_file, "shader.axsl");
+  EXPECT_TRUE(opts.verbose);
+}
+
+class ParseError : public testing::Test {
+protected:
+  void SetUp() override { old_buf_ = std::cerr.rdbuf(sink_.rdbuf()); }
+  void TearDown() override { std::cerr.rdbuf(old_buf_); }
+
+private:
+  std::ostringstream sink_;
+  std::streambuf *old_buf_;
+};
+
+TEST_F(ParseError, NoInputFile) {
+  Options opts;
+  EXPECT_FALSE(parse(make_tokens({}), opts));
+}
+
+TEST_F(ParseError, UnknownFlag) {
+  Options opts;
+  EXPECT_FALSE(parse(make_tokens({"--unknown"}), opts));
+}
+
+TEST_F(ParseError, MultipleInputFiles) {
+  Options opts;
+  EXPECT_FALSE(parse(make_tokens({"a.axsl", "b.axsl"}), opts));
+}
+
+TEST_F(ParseError, OutputMissingArgument) {
+  Options opts;
+  EXPECT_FALSE(parse(make_tokens({"-o"}), opts));
+}
+
+TEST_F(ParseError, OutputFollowedByFlag) {
+  Options opts;
+  EXPECT_FALSE(parse(make_tokens({"-o", "--verbose", "shader.axsl"}), opts));
+}
+
+TEST_F(ParseError, IncludePathMissingArgument) {
+  Options opts;
+  EXPECT_FALSE(parse(make_tokens({"-I"}), opts));
+}
+
+TEST(Parse, DefaultsAreClean) {
+  Options opts;
+  parse(make_tokens({"shader.axsl"}), opts);
+  EXPECT_FALSE(opts.verbose);
+  EXPECT_FALSE(opts.help);
+  EXPECT_FALSE(opts.version);
+  EXPECT_TRUE(opts.output_dir.empty());
+  EXPECT_TRUE(opts.include_path.empty());
+}

--- a/axslc/main.cpp
+++ b/axslc/main.cpp
@@ -1,0 +1,114 @@
+#include "args.hpp"
+#include "shader-lang/compiler.hpp"
+#include <filesystem>
+#include <fstream>
+#include <iostream>
+#include <sstream>
+
+namespace fs = std::filesystem;
+
+void print_usage(const char *prog) {
+  std::cout << "Usage: " << prog << " [options] <input.axsl>\n\n"
+            << "Options:\n"
+            << "  -o, --output <dir>         Output directory (default: "
+               "current directory)\n"
+            << "  -I, --include-path <path>  Include search path for @include "
+               "directives\n"
+            << "  -v, --verbose              Enable verbose output\n"
+            << "  -h, --help                 Display this help message\n"
+            << "  --version                  Display version information\n\n"
+            << "Examples:\n"
+            << "  " << prog << " shader.axsl\n"
+            << "  " << prog << " -o build/ shader.axsl\n"
+            << "  " << prog << " -I ./shaders -o build/ light.axsl\n";
+}
+
+void print_version() {
+  std::cout << "axslc - Astralix Shader Language Compiler\n"
+            << "Version 0.1.0\n";
+}
+
+int main(int argc, char **argv) {
+  Options opts;
+
+  if (!parse_args(argc, argv, opts)) {
+    std::cerr << "Try '" << argv[0] << " --help' for more information.\n";
+    return 1;
+  }
+
+  if (opts.help) {
+    print_usage(argv[0]);
+    return 0;
+  }
+
+  if (opts.version) {
+    print_version();
+    return 0;
+  }
+
+  std::ifstream file(opts.input_file);
+  if (!file) {
+    std::cerr << "error: cannot open '" << opts.input_file << "'\n";
+    return 1;
+  }
+
+  std::ostringstream buffer;
+  buffer << file.rdbuf();
+
+  if (opts.verbose) {
+    std::cout << "Compiling " << opts.input_file << "...\n";
+    if (!opts.include_path.empty())
+      std::cout << "Include path: " << opts.include_path << '\n';
+  }
+
+  std::string base_path;
+  if (!opts.include_path.empty()) {
+    base_path = opts.include_path;
+  } else {
+    fs::path input_path(opts.input_file);
+    if (input_path.has_parent_path())
+      base_path = input_path.parent_path().string();
+  }
+
+  astralix::Compiler compiler;
+  auto result = compiler.compile(buffer.str(), base_path, opts.input_file);
+
+  if (!result.ok()) {
+    for (const auto &e : result.errors)
+      std::cerr << e << '\n';
+    return 1;
+  }
+
+  if (opts.verbose) {
+    std::cout << "Compilation successful. Stages: " << result.stages.size()
+              << '\n';
+  }
+
+  fs::path input_stem = fs::path(opts.input_file).stem();
+  fs::path out_dir =
+      opts.output_dir.empty() ? fs::current_path() : fs::path(opts.output_dir);
+
+  static const std::pair<astralix::StageKind, const char *> stages[] = {
+      {astralix::StageKind::Vertex, "vert"},
+      {astralix::StageKind::Fragment, "frag"},
+      {astralix::StageKind::Geometry, "geom"},
+      {astralix::StageKind::Compute, "comp"},
+  };
+
+  for (auto [kind, extension] : stages) {
+    auto it = result.stages.find(kind);
+    if (it == result.stages.end())
+      continue;
+
+    fs::path path = out_dir / (input_stem.string() + "." + extension + ".glsl");
+    std::ofstream out(path);
+    if (!out) {
+      std::cerr << "error: cannot write to '" << path << "'\n";
+      return 1;
+    }
+    out << it->second;
+    std::cout << "wrote " << path.string() << '\n';
+  }
+
+  return 0;
+}

--- a/examples/sandbox/src/project_manifest.json
+++ b/examples/sandbox/src/project_manifest.json
@@ -134,8 +134,8 @@
     {
       "id": "shaders::skybox",
       "type": "Shader",
-      "vertex": "@engine/shaders/vertex/skybox.glsl",
-      "fragment": "@engine/shaders/fragment/skybox.glsl"
+      "vertex": "@engine/shaders/skybox.axsl",
+      "fragment": "@engine/shaders/skybox.axsl"
     },
     {
       "id": "shaders::glyph",

--- a/src/assets/shaders/hdr.axsl
+++ b/src/assets/shaders/hdr.axsl
@@ -1,0 +1,22 @@
+@version 450;
+
+in vec2 texture_coordinates;
+
+uniform sampler2D screen_texture;
+uniform float gamma = 1.1;
+uniform float exposure = 1.1;
+
+interface FragmentOutput {
+  vec4 color;
+}
+
+@fragment
+fn main() -> FragmentOutput {
+    vec3 color = texture(screen_texture, texture_coordinates).rgb;
+
+    vec3 mapped = vec3(1.) - exp(-color * exposure);
+
+    mapped = pow(mapped, vec3(1.0 / gamma));
+
+    FragmentOutput(vec4(mapped, 1.0));
+}

--- a/src/assets/shaders/helpers/kernel.axsl
+++ b/src/assets/shaders/helpers/kernel.axsl
@@ -1,0 +1,55 @@
+fn get_blur_kernel() -> float[9] {
+  float kernel[9] = float[](1.0 / 16, 2.0 / 16, 1.0 / 16, //
+                            2.0 / 16, 4.0 / 16, 2.0 / 16, //
+                            1.0 / 16, 2.0 / 16, 1.0 / 16);
+
+  return kernel;
+}
+
+fn get_edge_detection() -> float[9] {
+  float kernel[9] = float[](1, 1, 1,  //
+                            1, -8, 1, //
+                            1, 1, 1   //
+  );
+
+  return kernel;
+}
+
+fn get_sharpen_kernel() -> float[9] {
+  float kernel[9] = float[](-1, -1, -1, //
+                            -1, 9, -1,  //
+                            -1, -1, -1  //
+  );
+
+  return kernel;
+}
+
+fn apply_kernel(float kernel[9], float offset) -> vec3 {
+  vec2 offsets[9] = vec2[](vec2(-offset, offset), // top-left
+                           vec2(0., offset),      // top-center
+                           vec2(offset, offset),  // top-right
+
+                           vec2(-offset, 0.), // center-left
+                           vec2(0.),          // center-center
+                           vec2(offset, 0.),  // center-right
+
+                           vec2(-offset, -offset), // bottom-left
+                           vec2(0., -offset),      // bottom-center
+                           vec2(offset, -offset)   // bottom-right
+  );
+
+  vec3 sample_tex[9];
+
+  for (int i = 0; i < 9; i++) {
+    sample_tex[i] =
+        vec3(texture(screen_texture, _texture_cord.st + offsets[i]));
+  }
+
+  vec3 result = vec3(0.);
+
+  for (int i = 0; i < 9; i++) {
+    result += sample_tex[i] * kernel[i];
+  }
+
+  return result;
+}

--- a/src/assets/shaders/helpers/light.axsl
+++ b/src/assets/shaders/helpers/light.axsl
@@ -1,0 +1,122 @@
+@include "helpers/shadow.axsl";
+
+struct LightAttenuation {
+  float constant;
+  float linear;
+  float quadratic;
+};
+
+struct LightExposure {
+  vec3 ambient;
+  vec3 diffuse;
+  vec3 specular;
+};
+
+struct DirectionalLight {
+  LightExposure exposure;
+  vec3 direction;
+  vec3 position;
+};
+
+struct SpotLight {
+  LightExposure exposure;
+  vec3 direction;
+  vec3 position;
+  float inner_cut_off;
+  float outer_cut_off;
+};
+
+struct PointLight {
+  vec3 position;
+  LightExposure exposure;
+  LightAttenuation attenuation;
+};
+
+fn calc_directional_light(
+  sampler2D shadow_map,
+  sampler2D diffuse_map,
+  DirectionalLight light, 
+  vec3 normal, 
+  vec2 texture_coordinates,
+  vec3 tangent_light_position,
+  vec3 tangent_view_position,
+  vec3 tangent_fragment,
+  vec4 fragment_light_space
+) -> vec3 {
+    vec3 light_direction = normalize(tangent_light_position - tangent_fragment);
+    vec3 view_direction = normalize(tangent_view_position - tangent_fragment);
+
+    vec3 color = texture(diffuse_map, texture_coordinates).rgb;
+    vec3 ambient = light.exposure.ambient;
+    vec3 diffuse = light.exposure.diffuse * get_diffuse(light_direction, normal);
+    vec3 specular = light.exposure.specular * get_specular(light_direction, view_direction, normal);
+    float shadow = get_shadow(shadow_map, light_direction, normal, fragment_light_space);
+
+    return (ambient + shadow * (diffuse + specular)) * color;
+}
+
+fn calc_point_light(
+    PointLight light, 
+    sampler2D diffuse_map,
+    vec3 view_direction, 
+    vec3 normal, 
+    vec2 texture_coordinates,
+    vec3 tangent_light_position,
+    vec3 tangent_view_position,
+    vec3 tangent_fragment
+) -> vec3 {
+    vec3 direction = normalize(light.position - tangent_fragment);
+    vec3 color = texture(diffuse_map, texture_coordinates).rgb;
+    float distance = length(light.position - tangent_fragment);
+    float attenuation = get_attenuation(distance, light.attenuation);
+    vec3 ambient = light.exposure.ambient;
+    vec3 diffuse = light.exposure.diffuse * get_diffuse(direction, normal);
+    vec3 specular = light.exposure.specular * get_specular(direction, view_direction, normal);
+
+    return (ambient + diffuse + specular) * color;
+}
+
+fn parallax_mapping(
+    sampler2D displacement_map,
+    vec2 texture_coordinates, 
+    vec3 view_direction,
+    float height_scale
+) -> vec2 {
+    const float min_layers = 8.0;
+    const float max_layers = 32.0;
+    float layers = mix(max_layers, min_layers, max(dot(vec3(0.0, 0.0, 1.0), view_direction), 0.0));
+
+    float layer_depth = 1.0 / layers;
+    float current_layer_depth = 0.0;
+    vec2 p = view_direction.xy * height_scale;
+    vec2 delta_texture_coordinates = p / layers;
+    vec2 current_texture_coordinates = texture_coordinates;
+    float current_displacement_map = texture(displacement_map, current_texture_coordinates).r;
+
+    while (current_layer_depth < current_displacement_map) {
+        current_texture_coordinates -= delta_texture_coordinates;
+        current_displacement_map = texture(displacement_map, current_texture_coordinates).r;
+        current_layer_depth += layer_depth;
+    }
+
+    vec2 previous_texture_coordinates = current_texture_coordinates + delta_texture_coordinates;
+    float after_displacement = current_displacement_map - current_layer_depth;
+    float before_displacement = texture(displacement_map, previous_texture_coordinates).r - current_layer_depth + layer_depth;
+    float weight = after_displacement / (after_displacement - before_displacement);
+
+    return previous_texture_coordinates * weight + current_texture_coordinates * (1.0 - weight);
+}
+
+fn get_specular(vec3 light_direction, vec3 view_direction, vec3 normal) -> float {
+    vec3 halfway_direction = normalize(light_direction + view_direction);
+    float halfDot = max(dot(normal, halfway_direction), 0.0);
+    return pow(halfDot, 32.0);
+}
+
+fn get_diffuse(vec3 light_direction, vec3 normal) -> float {
+    return max(dot(light_direction, normal), 0.);
+}
+
+fn get_attenuation(float distance, LightAttenuation attenuation) -> float {
+    return 1. / (attenuation.constant + attenuation.linear * distance + attenuation.quadratic * (distance * distance));
+}

--- a/src/assets/shaders/helpers/shadow.axsl
+++ b/src/assets/shaders/helpers/shadow.axsl
@@ -1,0 +1,28 @@
+fn get_shadow(
+    sampler2D shadow_map,
+    vec3 light_direction, 
+    vec3 normal, 
+    vec4 fragment_light_space
+) -> float {
+    vec3 projection_coordinates = fragment_light_space.xyz / fragment_light_space.w;
+
+    float current_depth = projection_coordinates.z;
+    float bias = max(0.05 * (1.0 - dot(normal, light_direction)), 0.05);
+    float shadow = 0.0;
+    vec2 texelSize = 1.0 / textureSize(shadow_map, 0);
+
+    for (int x = -1; x <= 1; ++x) {
+        for (int y = -1; y <= 1; ++y) {
+            float pcfDepth = texture(shadow_map, projection_coordinates.xy + vec2(x, y) * texelSize).r;
+            shadow += current_depth - bias > pcfDepth ? 1.0 : 0.0;
+        }
+    }
+
+    shadow /= 9.0;
+
+    if (projection_coordinates.z > 1.0) {
+        shadow = 0.0;
+    }
+
+    return 1.0 - shadow;
+}

--- a/src/assets/shaders/light.axsl
+++ b/src/assets/shaders/light.axsl
@@ -1,0 +1,165 @@
+@version 450;
+
+@include "helpers/light.axsl";
+@include "helpers/shadow.axsl";
+
+
+struct Material {
+  sampler2D diffuse;
+  sampler2D specular;
+  float shininess;
+};
+
+uniform vec3 view_position; 
+uniform DirectionalLight directional_light;
+
+@in
+interface Mesh {
+  @location(0) 
+  vec3 position;
+
+  @location(1) 
+  vec3 normal;
+
+  @location(2) 
+  vec2 texture_coordinates;
+
+  @location(3) 
+  vec3 tangent;
+}
+
+@std430 
+@binding(0) 
+in InstanceBuffer {
+    mat4 models[];
+} instance;
+
+@uniform 
+interface Entity {
+  mat4 view;
+  mat4 projection;
+  mat4 g_model;
+  mat4 light_space_matrix;
+  bool use_instancing = false;
+}
+
+interface VertexOutput {
+  vec2 texture;
+  vec3 fragment;
+  mat4 model;
+  vec4 fragment_light_space;
+  vec4 tangent_fragment_light_space;
+  vec3 tangent_fragment;
+  vec3 tangent_light_position;
+  vec3 tangent_view_position;
+  vec3 normal;
+}
+
+@vertex
+fn main(Entity entity, Mesh mesh) -> VertexOutput {
+  mat4 model = entity.use_instancing ? instance.models[gl_InstanceID] : entity.g_model;
+
+  mat4 normalMatrix = transpose(inverse(model));
+
+  vec3 T = normalize(normalMatrix * vec4(mesh.tangent, 0.)).xyz;
+  vec3 N = normalize(normalMatrix * vec4(mesh.normal, 0.)).xyz;
+
+  T = normalize(T - dot(T, N) * N);
+
+  vec3 B = cross(N, T);
+
+  mat3 TBN = transpose(mat3(T, B, N));
+
+  VertexOutput vertex_output;
+
+  vertex_output.model = model;
+  vertex_output.fragment = vec3(model * vec4(mesh.position, 1.));
+  vertex_output.tangent_fragment = TBN * vertex_output.fragment;
+  vertex_output.tangent_view_position = TBN * view_position;
+  vertex_output.tangent_light_position = TBN * directional_light.position;
+  vertex_output.texture = mesh.texture_coordinates;
+  vertex_output.fragment_light_space = entity.light_space_matrix * vec4(vertex_output.fragment, 1.0);
+  vertex_output.tangent_fragment_light_space = entity.light_space_matrix * vec4(vertex_output.tangent_fragment, 1.0);
+  vertex_output.normal = transpose(inverse(mat3(model))) * mesh.normal;
+
+  gl_Position = entity.projection * entity.view * model * vec4(mesh.position, 1.0);
+
+  return vertex_output;
+}
+
+@uniform
+interface FragmentInput {
+  Material materials[1];
+  SpotLight spot_light;
+  PointLight point_lights[4];
+  DirectionalLight directional_light;
+  float near_plane = -10.0;
+  float far_plane = 20.0;
+  sampler2D normal_map;
+  sampler2D displacement_map;
+  sampler2D shadow_map;
+  float height_scale = 0.1;
+}
+
+interface FragmentOutput {
+  @location(0)
+  vec4 color;
+
+  @location(1)
+  vec4 bright_color;
+}
+
+@fragment
+fn main(VertexOutput vertex, FragmentInput fragment) -> FragmentOutput {
+  vec3 view_direction = normalize(vertex.tangent_view_position - vertex.tangent_fragment);
+  vec2 texture_coordinates = parallax_mapping(
+      fragment.displacement_map, 
+      vertex.texture, 
+      view_direction,
+      fragment.height_scale
+  );
+
+  vec3 normal = texture2D(fragment.normal_map, texture_coordinates).rgb * 2. - 1.;
+  normal = normalize(normal);
+
+  vec3 result = vec3(0.);
+
+  result += calc_directional_light(
+      fragment.shadow_map,
+      fragment.materials[0].diffuse,
+      directional_light, 
+      normal, 
+      texture_coordinates,
+      vertex.tangent_light_position,
+      vertex.tangent_view_position,
+      vertex.tangent_fragment,
+      vertex.fragment_light_space
+  );
+
+  for (int i = 0; i < 4; ++i) {
+    result += calc_point_light(
+        fragment.point_lights[i], 
+        fragment.materials[0].diffuse,
+        view_direction, 
+        normal, 
+        texture_coordinates,
+        vertex.tangent_light_position,
+        vertex.tangent_view_position,
+        vertex.tangent_fragment
+    );
+  }
+
+  FragmentOutput frag_output;
+
+  frag_output.color = vec4(result, 1);
+
+  float brightness = dot(frag_output.color.rgb, vec3(0.2126, 0.7152, 0.0722));
+
+  if (brightness > 1.0) {
+    frag_output.bright_color = vec4(frag_output.color.rgb, 1.0);
+  } else {
+    frag_output.bright_color = vec4(0.0, 0.0, 0.0, 1.0);
+  }
+
+  return frag_output;
+}

--- a/src/assets/shaders/skybox.axsl
+++ b/src/assets/shaders/skybox.axsl
@@ -1,0 +1,41 @@
+@version 450;
+
+uniform mat4 view_without_transformation;
+uniform mat4 projection;
+
+@in
+interface VertexInput {
+  @location(0) 
+  vec3 position;
+}
+
+interface VertexOutput {
+  @location(0) 
+  vec3 texture_coordinate;
+}
+
+interface FragmentInput {
+  @uniform
+  samplerCube skybox;
+}
+
+interface FragmentOutput {
+  @location(0) 
+  vec4 color;
+}
+
+@vertex
+fn main(VertexInput input) -> VertexOutput {
+  vec4 pos = projection * view_without_transformation * vec4(input.position, 1.);
+
+  gl_Position = pos.xyww;
+
+  return VertexOutput(input.position);
+}
+
+@fragment 
+fn main(VertexOutput vertex, FragmentInput fragment) -> FragmentOutput {
+  vec4 color = texture(fragment.skybox, vertex.texture_coordinate);
+
+  return FragmentOutput(color);
+}

--- a/src/modules/renderer/platform/OpenGL/opengl-shader.cpp
+++ b/src/modules/renderer/platform/OpenGL/opengl-shader.cpp
@@ -3,10 +3,12 @@
 #include "glad/glad.h"
 #include "log.hpp"
 
+#include "filesystem"
 #include "fstream"
 #include "iostream"
 #include "managers/path-manager.hpp"
 #include "resources/shader.hpp"
+#include "shader-lang/compiler.hpp"
 #include "sstream"
 #include <cstring>
 
@@ -15,14 +17,147 @@ namespace astralix {
 OpenGLShader::OpenGLShader(const ResourceHandle &resource_id,
                            Ref<ShaderDescriptor> descriptor)
     : Shader(resource_id, descriptor->id) {
-  m_renderer_id = glCreateProgram();
 
-  m_vertex_id = compile(descriptor->vertex_path, GL_VERTEX_SHADER);
-  m_fragment_id = compile(descriptor->fragment_path, GL_FRAGMENT_SHADER);
+  Compiler compiler;
 
-  if (descriptor->geometry_path != nullptr) {
-    m_geometry_id = compile(descriptor->geometry_path, GL_GEOMETRY_SHADER);
+  auto vertex_path = PathManager::get()->resolve(descriptor->vertex_path);
+  auto fragment_path = PathManager::get()->resolve(descriptor->fragment_path);
+
+  auto validate_extension = [](const std::filesystem::path &resolved) {
+    auto extension = resolved.extension().string();
+
+    ASTRA_ENSURE(extension != ".axsl" && extension != ".glsl",
+                 "Unsupported shader file extension '" + extension + "' in '" +
+                     resolved.string() + "': expected .axsl or .glsl");
+  };
+
+  validate_extension(vertex_path);
+  validate_extension(fragment_path);
+
+  std::filesystem::path geometry_path;
+
+  if (descriptor->geometry_path) {
+    geometry_path = PathManager::get()->resolve(descriptor->geometry_path);
+    validate_extension(geometry_path);
   }
+
+  static constexpr std::pair<StageKind, const char *> stage_extensions[] = {
+      {StageKind::Vertex, "vert"},
+      {StageKind::Fragment, "frag"},
+      {StageKind::Geometry, "geom"},
+      {StageKind::Compute, "comp"},
+  };
+
+  auto cache_path = [&](const std::filesystem::path &resolved,
+                        const char *ext) {
+    return resolved.parent_path() /
+           (resolved.stem().string() + "." + ext + ".glsl");
+  };
+
+  std::map<std::string, CompileResult> axsl_results;
+
+  auto ensure_compiled = [&](const std::filesystem::path &resolved) {
+    if (resolved.extension() != ".axsl") {
+      return;
+    }
+
+    auto key = resolved.string();
+
+    if (axsl_results.count(key)) {
+      return;
+    }
+
+    auto source_mtime = std::filesystem::last_write_time(resolved);
+    bool any_exists = false;
+    bool any_stale = false;
+
+    for (auto [kind, ext] : stage_extensions) {
+      auto cached = cache_path(resolved, ext);
+      if (!std::filesystem::exists(cached))
+        continue;
+      any_exists = true;
+      if (std::filesystem::last_write_time(cached) < source_mtime) {
+        any_stale = true;
+        break;
+      }
+    }
+
+    if (any_exists && !any_stale) {
+      CompileResult cached_result;
+      for (auto [kind, ext] : stage_extensions) {
+        auto cached = cache_path(resolved, ext);
+        if (!std::filesystem::exists(cached))
+          continue;
+        std::ifstream file(cached);
+        std::ostringstream buffer;
+        buffer << file.rdbuf();
+        cached_result.stages[kind] = buffer.str();
+      }
+      axsl_results[key] = std::move(cached_result);
+      return;
+    }
+
+    std::ifstream file(resolved);
+    std::ostringstream buffer;
+    buffer << file.rdbuf();
+    auto result = compiler.compile(
+        buffer.str(), resolved.parent_path().string(), resolved.string());
+
+    if (result.ok()) {
+      for (auto [kind, ext] : stage_extensions) {
+        auto it = result.stages.find(kind);
+
+        if (it == result.stages.end()) {
+          continue;
+        }
+        std::ofstream out(cache_path(resolved, ext));
+        out << it->second;
+      }
+    }
+
+    axsl_results[key] = std::move(result);
+  };
+
+  ensure_compiled(vertex_path);
+  ensure_compiled(fragment_path);
+
+  if (!geometry_path.empty()) {
+    ensure_compiled(geometry_path);
+  }
+
+  for (auto &[path, result] : axsl_results) {
+    if (!result.ok()) {
+      std::string error_message;
+
+      for (auto &error : result.errors) {
+        error_message += error + "\n";
+      }
+      ASTRA_EXCEPTION(error_message);
+    }
+  }
+
+  auto load_stage = [&](const std::filesystem::path &resolved, StageKind kind,
+                        uint32_t gl_type) -> uint32_t {
+    if (resolved.extension() == ".axsl") {
+      auto &stages = axsl_results.at(resolved.string()).stages;
+      auto it = stages.find(kind);
+      return it != stages.end() ? compile_glsl(it->second, gl_type)
+                                : static_cast<uint32_t>(-1);
+    }
+    std::ifstream file(resolved);
+    std::ostringstream buffer;
+    buffer << file.rdbuf();
+    return compile_glsl(buffer.str(), gl_type);
+  };
+
+  m_renderer_id = glCreateProgram();
+  m_vertex_id = load_stage(vertex_path, StageKind::Vertex, GL_VERTEX_SHADER);
+  m_fragment_id =
+      load_stage(fragment_path, StageKind::Fragment, GL_FRAGMENT_SHADER);
+
+  if (!geometry_path.empty())
+    m_geometry_id =
+        load_stage(geometry_path, StageKind::Geometry, GL_GEOMETRY_SHADER);
 
   attach();
 }
@@ -98,15 +233,11 @@ static std::string get_file_content_str(Ref<Path> filename) {
   return buffer.str();
 }
 
-uint32_t OpenGLShader::compile(Ref<Path> path, uint32_t type) {
+uint32_t OpenGLShader::compile_glsl(const std::string &source, uint32_t type) {
   uint32_t shader_id = glCreateShader(type);
 
-  auto source = get_file_content_str(path);
-
   const char *shader_source = source.c_str();
-
   glShaderSource(shader_id, 1, &shader_source, NULL);
-
   glCompileShader(shader_id);
 
   int success;
@@ -116,14 +247,14 @@ uint32_t OpenGLShader::compile(Ref<Path> path, uint32_t type) {
     std::vector<char> shader_error(1024);
     glGetShaderInfoLog(shader_id, shader_error.size(), nullptr,
                        shader_error.data());
-
-    std::string error = "Can't load shader from " + path->get_relative_path() +
-                        "\n" +
-                        std::string(shader_error.begin(), shader_error.end());
-    ASTRA_EXCEPTION(error);
-  };
+    ASTRA_EXCEPTION(std::string(shader_error.begin(), shader_error.end()));
+  }
 
   return shader_id;
-};
+}
+
+uint32_t OpenGLShader::compile(Ref<Path> path, uint32_t type) {
+  return compile_glsl(get_file_content_str(path), type);
+}
 
 } // namespace astralix

--- a/src/modules/renderer/platform/OpenGL/opengl-shader.hpp
+++ b/src/modules/renderer/platform/OpenGL/opengl-shader.hpp
@@ -23,6 +23,7 @@ public:
 
 private:
   uint32_t compile(Ref<Path> path, uint32_t type);
+  uint32_t compile_glsl(const std::string &source, uint32_t type);
 
   uint32_t m_renderer_id = -1;
   uint32_t m_vertex_id = -1;

--- a/src/modules/renderer/shader-lang/ast.hpp
+++ b/src/modules/renderer/shader-lang/ast.hpp
@@ -1,0 +1,636 @@
+#pragma once
+#include "shader-lang/token.hpp"
+#include <cstdint>
+#include <optional>
+#include <string>
+#include <variant>
+#include <vector>
+
+namespace astralix {
+using NodeID = uint32_t;
+
+enum class StageKind : uint8_t { Vertex, Fragment, Geometry, Compute };
+
+enum class ParamQualifier : uint8_t { None, In, Out, Inout, Const };
+
+enum class AttributeKind : uint8_t {
+  In,
+  Uniform,
+  Location,
+  Binding,
+  Set,
+  Std140,
+  Std430,
+  PushConstant,
+  VertexStage,
+  FragmentStage,
+  GeometryStage,
+  ComputeStage
+};
+
+inline std::string_view attribute_kind_name(AttributeKind kind) {
+  switch (kind) {
+    case AttributeKind::In:
+      return "@in";
+    case AttributeKind::Uniform:
+      return "@uniform";
+    case AttributeKind::Location:
+      return "@location";
+    case AttributeKind::Binding:
+      return "@binding";
+    case AttributeKind::Set:
+      return "@set";
+    case AttributeKind::Std140:
+      return "@std140";
+    case AttributeKind::Std430:
+      return "@std430";
+    case AttributeKind::PushConstant:
+      return "@push_constant";
+
+    case AttributeKind::VertexStage:
+      return "@vertex";
+
+    case AttributeKind::FragmentStage:
+      return "@fragment";
+
+    case AttributeKind::GeometryStage:
+      return "@geometry";
+  }
+
+  return "@<unknown>";
+}
+
+using AttributeValue = std::variant<std::monostate, StageKind, int32_t>;
+
+struct Attribute {
+  AttributeKind kind;
+  AttributeValue value{};
+  SourceLocation location;
+};
+
+using AttributeList = std::vector<Attribute>;
+
+enum class InterfaceRole : uint8_t {
+  None,
+  In,
+  Uniform,
+};
+
+enum class AnnotationKind : uint8_t {
+  In,
+  Uniform,
+  Location,
+  Binding,
+  Set,
+  Std140,
+  Std430,
+  PushConstant,
+};
+
+inline std::string_view annotation_kind_name(AnnotationKind kind) {
+  switch (kind) {
+    case AnnotationKind::In:
+      return "@in";
+    case AnnotationKind::Uniform:
+      return "@uniform";
+    case AnnotationKind::Location:
+      return "@location";
+    case AnnotationKind::Binding:
+      return "@binding";
+    case AnnotationKind::Set:
+      return "@set";
+    case AnnotationKind::Std140:
+      return "@std140";
+    case AnnotationKind::Std430:
+      return "@std430";
+    case AnnotationKind::PushConstant:
+      return "@push_constant";
+  }
+
+  return "@<unknown>";
+}
+
+struct TypeRef {
+  TokenKind kind;
+  std::string name;
+  std::optional<uint32_t> array_size;
+  bool is_runtime_sized = false;
+};
+
+struct Annotation {
+  AnnotationKind kind;
+  int32_t slot = -1;
+  int32_t set = -1;
+  SourceLocation location;
+};
+
+using Annotations = std::vector<Annotation>;
+
+struct LiteralExpr {
+  std::variant<bool, int64_t, double> value;
+
+  void visit_offset(NodeID) {}
+  template <class Fn> void visit_child_ids(Fn &&) const {}
+};
+
+struct IdentifierExpr {
+  std::string name;
+
+  void visit_offset(NodeID) {}
+  template <class Fn> void visit_child_ids(Fn &&) const {}
+};
+
+struct UnresolvedRef {
+  std::string name;
+
+  void visit_offset(NodeID) {}
+  template <class Fn> void visit_child_ids(Fn &&) const {}
+};
+
+struct BinaryExpr {
+  NodeID lhs, rhs;
+  TokenKind op;
+
+  void visit_offset(NodeID off) {
+    lhs += off;
+    rhs += off;
+  }
+
+  template <class Fn> void visit_child_ids(Fn &&fn) const {
+    fn(lhs);
+    fn(rhs);
+  }
+};
+
+struct UnaryExpr {
+  NodeID operand;
+  TokenKind op;
+  bool prefix;
+
+  void visit_offset(NodeID off) { operand += off; }
+  template <class Fn> void visit_child_ids(Fn &&fn) const { fn(operand); }
+};
+
+struct TernaryExpr {
+  NodeID cond, then_expr, else_expr;
+
+  void visit_offset(NodeID off) {
+    cond += off;
+    then_expr += off;
+    else_expr += off;
+  }
+
+  template <class Fn> void visit_child_ids(Fn &&fn) const {
+    fn(cond);
+    fn(then_expr);
+    fn(else_expr);
+  }
+};
+
+struct CallExpr {
+  NodeID callee;
+  std::vector<NodeID> args;
+
+  void visit_offset(NodeID off) {
+    callee += off;
+
+    for (auto &arg : args) {
+      arg += off;
+    }
+  }
+
+  template <class Fn> void visit_child_ids(Fn &&fn) const {
+    fn(callee);
+    for (NodeID arg : args) {
+      fn(arg);
+    }
+  }
+};
+
+struct IndexExpr {
+  NodeID array, index;
+
+  void visit_offset(NodeID off) {
+    array += off;
+    index += off;
+  }
+
+  template <class Fn> void visit_child_ids(Fn &&fn) const {
+    fn(array);
+    fn(index);
+  }
+};
+
+struct FieldExpr {
+  NodeID object;
+  std::string field;
+
+  void visit_offset(NodeID off) { object += off; }
+  template <class Fn> void visit_child_ids(Fn &&fn) const { fn(object); }
+};
+
+struct ConstructExpr {
+  TypeRef type;
+  std::vector<NodeID> args;
+
+  void visit_offset(NodeID off) {
+    for (auto &arg : args) {
+      arg += off;
+    }
+  }
+
+  template <class Fn> void visit_child_ids(Fn &&fn) const {
+    for (NodeID arg : args) {
+      fn(arg);
+    }
+  }
+};
+
+struct AssignExpr {
+  NodeID lhs, rhs;
+  TokenKind op;
+
+  void visit_offset(NodeID off) {
+    lhs += off;
+    rhs += off;
+  }
+
+  template <class Fn> void visit_child_ids(Fn &&fn) const {
+    fn(lhs);
+    fn(rhs);
+  }
+};
+
+struct BlockStmt {
+  std::vector<NodeID> stmts;
+
+  void visit_offset(NodeID off) {
+    for (auto &stmt : stmts) {
+      stmt += off;
+    }
+  }
+
+  template <class Fn> void visit_child_ids(Fn &&fn) const {
+    for (NodeID stmt : stmts) {
+      fn(stmt);
+    }
+  }
+};
+
+struct IfStmt {
+  NodeID cond;
+  NodeID then_br;
+  std::optional<NodeID> else_br;
+  void visit_offset(NodeID off) {
+    cond += off;
+    then_br += off;
+
+    if (else_br) {
+      *else_br += off;
+    }
+  }
+
+  template <class Fn> void visit_child_ids(Fn &&fn) const {
+    fn(cond);
+    fn(then_br);
+    if (else_br) {
+      fn(*else_br);
+    }
+  }
+};
+
+struct ForStmt {
+  NodeID init;
+  std::optional<NodeID> cond, step;
+  NodeID body;
+
+  void visit_offset(NodeID off) {
+    init += off;
+
+    if (cond) {
+      *cond += off;
+    }
+
+    if (step) {
+      *step += off;
+    }
+
+    body += off;
+  }
+
+  template <class Fn> void visit_child_ids(Fn &&fn) const {
+    fn(init);
+    if (cond) {
+      fn(*cond);
+    }
+    if (step) {
+      fn(*step);
+    }
+    fn(body);
+  }
+};
+
+struct WhileStmt {
+  NodeID cond, body;
+
+  void visit_offset(NodeID off) {
+    cond += off;
+    body += off;
+  }
+
+  template <class Fn> void visit_child_ids(Fn &&fn) const {
+    fn(cond);
+    fn(body);
+  }
+};
+
+struct ReturnStmt {
+  std::optional<NodeID> value;
+
+  void visit_offset(NodeID off) {
+    if (value)
+      *value += off;
+  }
+
+  template <class Fn> void visit_child_ids(Fn &&fn) const {
+    if (value) {
+      fn(*value);
+    }
+  }
+};
+
+struct ExprStmt {
+  NodeID expr;
+
+  void visit_offset(NodeID off) { expr += off; }
+  template <class Fn> void visit_child_ids(Fn &&fn) const { fn(expr); }
+};
+
+struct DeclStmt {
+  NodeID decl;
+
+  void visit_offset(NodeID off) { decl += off; }
+  template <class Fn> void visit_child_ids(Fn &&fn) const { fn(decl); }
+};
+
+struct BreakStmt {
+  void visit_offset(NodeID) {}
+  template <class Fn> void visit_child_ids(Fn &&) const {}
+};
+
+struct ContinueStmt {
+  void visit_offset(NodeID) {}
+  template <class Fn> void visit_child_ids(Fn &&) const {}
+};
+
+struct DiscardStmt {
+  void visit_offset(NodeID) {}
+  template <class Fn> void visit_child_ids(Fn &&) const {}
+};
+
+struct VarDecl {
+  TypeRef type;
+  std::string name;
+  std::optional<NodeID> init;
+  bool is_const = false;
+
+  void visit_offset(NodeID off) {
+    if (init) {
+      *init += off;
+    }
+  }
+
+  template <class Fn> void visit_child_ids(Fn &&fn) const {
+    if (init) {
+      fn(*init);
+    }
+  }
+};
+
+struct ParamDecl {
+  TypeRef type;
+  std::string name;
+  ParamQualifier qual;
+
+  void visit_offset(NodeID) {}
+  template <class Fn> void visit_child_ids(Fn &&) const {}
+};
+
+struct FuncDecl {
+  TypeRef ret;
+  std::string name;
+  std::vector<NodeID> params;
+  NodeID body;
+
+  std::optional<StageKind> stage_kind;
+
+  void visit_offset(NodeID off) {
+    for (auto &param : params) {
+      param += off;
+    }
+    body += off;
+  }
+
+  template <class Fn> void visit_child_ids(Fn &&fn) const {
+    for (NodeID param : params) {
+      fn(param);
+    }
+    fn(body);
+  }
+};
+
+struct StructDecl {
+  std::string name;
+  std::vector<NodeID> fields;
+
+  void visit_offset(NodeID off) {
+    for (auto &field : fields) {
+      field += off;
+    }
+  }
+
+  template <class Fn> void visit_child_ids(Fn &&fn) const {
+    for (NodeID field : fields) {
+      fn(field);
+    }
+  }
+};
+
+struct FieldDecl {
+  TypeRef type;
+  std::string name;
+
+  std::optional<uint32_t> array_size;
+
+  std::optional<NodeID> init;
+
+  Annotations annotations;
+
+  void visit_offset(NodeID off) {
+    if (init) {
+      *init += off;
+    }
+  }
+
+  template <class Fn> void visit_child_ids(Fn &&fn) const {
+    if (init) {
+      fn(*init);
+    }
+  }
+};
+
+struct UniformDecl {
+  TypeRef type;
+  std::string name;
+  Annotations annotations;
+  std::optional<NodeID> default_val;
+
+  std::optional<uint32_t> array_size;
+
+  void visit_offset(NodeID off) {
+    if (default_val) {
+      *default_val += off;
+    }
+  }
+
+  template <class Fn> void visit_child_ids(Fn &&fn) const {
+    if (default_val) {
+      fn(*default_val);
+    }
+  }
+};
+
+struct BufferDecl {
+  std::string name;
+  std::vector<NodeID> fields;
+  Annotations annotations;
+  std::optional<std::string> instance_name;
+  bool is_uniform = false;
+
+  void visit_offset(NodeID off) {
+    for (auto &field : fields) {
+      field += off;
+    }
+  }
+
+  template <class Fn> void visit_child_ids(Fn &&fn) const {
+    for (NodeID field : fields) {
+      fn(field);
+    }
+  }
+};
+
+struct InterfaceDecl {
+  std::string name;
+  std::vector<NodeID> fields;
+  InterfaceRole role = InterfaceRole::None;
+  std::optional<std::string> implicit_instance_name;
+
+  void visit_offset(NodeID off) {
+    for (auto &field : fields) {
+      field += off;
+    }
+  }
+
+  template <class Fn> void visit_child_ids(Fn &&fn) const {
+    for (NodeID field : fields) {
+      fn(field);
+    }
+  }
+};
+
+struct Decorator {
+  std::optional<StageKind> stage;
+  InterfaceRole interface_role = InterfaceRole::None;
+};
+
+struct InlineInterfaceDecl {
+  bool is_in;
+  std::string name;
+  std::vector<NodeID> fields;
+  std::optional<std::string> instance_name;
+
+  Annotations annotations;
+
+  void visit_offset(NodeID off) {
+    for (auto &field : fields)
+      field += off;
+  }
+
+  template <class Fn> void visit_child_ids(Fn &&fn) const {
+    for (NodeID field : fields) {
+      fn(field);
+    }
+  }
+};
+
+struct InterfaceRef {
+  bool is_in;
+  std::string block_name;
+  std::optional<std::string> instance_name;
+  void visit_offset(NodeID) {}
+  template <class Fn> void visit_child_ids(Fn &&) const {}
+};
+
+struct StageBlock {
+  StageKind kind;
+  std::vector<NodeID> items;
+
+  void visit_offset(NodeID off) {
+    for (auto &item : items) {
+      item += off;
+    }
+  }
+
+  template <class Fn> void visit_child_ids(Fn &&fn) const {
+    for (NodeID item : items) {
+      fn(item);
+    }
+  }
+};
+
+struct Program {
+  int version;
+  std::vector<std::string> includes;
+  std::vector<NodeID> globals;
+  std::vector<NodeID> stages;
+
+  void visit_offset(NodeID) {}
+  template <class Fn> void visit_child_ids(Fn &&fn) const {
+    for (NodeID global : globals) {
+      fn(global);
+    }
+    for (NodeID stage : stages) {
+      fn(stage);
+    }
+  }
+};
+
+using ASTNodeData =
+    std::variant<LiteralExpr, IdentifierExpr, UnresolvedRef, BinaryExpr,
+                 UnaryExpr, TernaryExpr, CallExpr, IndexExpr, FieldExpr,
+                 ConstructExpr, AssignExpr, BlockStmt, IfStmt, ForStmt,
+                 WhileStmt, ReturnStmt, ExprStmt, DeclStmt, BreakStmt,
+                 ContinueStmt, DiscardStmt, VarDecl, ParamDecl, FuncDecl,
+                 StructDecl, FieldDecl, UniformDecl, BufferDecl, InterfaceDecl,
+                 InlineInterfaceDecl, StageBlock, InterfaceRef, Program>;
+
+struct ASTNode {
+  NodeID id;
+  SourceLocation location;
+  TypeRef type;
+  ASTNodeData data;
+};
+
+template <class Fn>
+inline void visit_child_ids(const ASTNodeData &data, Fn &&fn) {
+  auto &&visitor = fn;
+  std::visit([&visitor](const auto &node) { node.visit_child_ids(visitor); },
+             data);
+}
+
+template <class Fn> inline void visit_child_ids(const ASTNode &node, Fn &&fn) {
+  visit_child_ids(node.data, fn);
+}
+
+}; // namespace astralix

--- a/src/modules/renderer/shader-lang/compiler.cpp
+++ b/src/modules/renderer/shader-lang/compiler.cpp
@@ -1,0 +1,63 @@
+#include "shader-lang/compiler.hpp"
+#include "shader-lang/emitters/opengl-glsl-emitter.hpp"
+#include "shader-lang/linker.hpp"
+#include "shader-lang/parser.hpp"
+#include "shader-lang/tokenizer.hpp"
+
+namespace astralix {
+
+static std::pair<std::vector<Token>, std::vector<std::string>>
+tokenize_source(std::string_view src, std::string_view filename = "") {
+  Tokenizer tokenizer(src, filename);
+  std::vector<Token> tokens;
+
+  while (true) {
+    Token token = tokenizer.next();
+    tokens.push_back(token);
+    if (token.kind == TokenKind::EoF)
+      break;
+  }
+
+  return {std::move(tokens), tokenizer.errors()};
+}
+
+CompileResult Compiler::compile(std::string_view source,
+                                std::string_view base_path,
+                                std::string_view filename) {
+  CompileResult result;
+
+  auto [tokens, token_errors] = tokenize_source(source, filename);
+
+  if (!token_errors.empty()) {
+    result.errors = token_errors;
+    return result;
+  }
+
+  Parser main_parser(std::move(tokens), source);
+  Program program = main_parser.parse();
+
+  if (!main_parser.errors().empty()) {
+    result.errors = main_parser.errors();
+    return result;
+  }
+
+  Linker linker;
+  LinkResult link_result = linker.link(program, main_parser.nodes(), base_path);
+
+  if (!link_result.ok()) {
+    result.errors = link_result.errors;
+    return result;
+  }
+
+  OpenGLGLSLEmitter emitter(link_result.all_nodes);
+  for (NodeID sid : program.stages) {
+    const auto &func_decl = std::get<FuncDecl>(link_result.all_nodes[sid].data);
+    result.stages[func_decl.stage_kind.value()] =
+        emitter.emit(program, func_decl.stage_kind.value(),
+                     link_result.uniform_usage[func_decl.stage_kind.value()]);
+  }
+
+  return result;
+}
+
+} // namespace astralix

--- a/src/modules/renderer/shader-lang/compiler.hpp
+++ b/src/modules/renderer/shader-lang/compiler.hpp
@@ -1,0 +1,23 @@
+#pragma once
+#include "shader-lang/ast.hpp"
+#include <map>
+#include <string>
+#include <string_view>
+#include <vector>
+
+namespace astralix {
+
+struct CompileResult {
+  std::map<StageKind, std::string> stages;
+  std::vector<std::string> errors;
+  bool ok() const { return errors.empty(); }
+};
+
+class Compiler {
+public:
+  CompileResult compile(std::string_view source,
+                        std::string_view base_path = {},
+                        std::string_view filename = {});
+};
+
+} // namespace astralix

--- a/src/modules/renderer/shader-lang/compiler.test.cpp
+++ b/src/modules/renderer/shader-lang/compiler.test.cpp
@@ -1,0 +1,1828 @@
+#include "shader-lang/compiler.hpp"
+#include "shader-lang/diagnostics.hpp"
+#include <filesystem>
+#include <fstream>
+#include <gtest/gtest.h>
+
+namespace astralix {
+
+static constexpr std::string_view k_full_source = R"axsl(
+@version 450;
+
+struct Material {
+    vec3 albedo;
+    float roughness;
+};
+
+const float PI = 3.14159;
+
+@in
+interface Attributes {
+    @location(0) vec3 a_pos;
+    @location(1) vec2 a_uv;
+    @location(2) vec3 a_normal;
+}
+
+interface Varyings {
+    vec2 v_uv;
+    vec3 v_normal;
+}
+
+interface FragmentOutput {
+    @location(0) vec4 color;
+}
+
+@binding(0) uniform mat4 u_mvp;
+@binding(1) uniform mat4 u_model;
+@binding(2) uniform MaterialBlock {
+    Material u_mat;
+} materials;
+@binding(3) uniform sampler2D u_tex;
+
+fn gamma(vec3 c) -> vec3 {
+    return pow(c, vec3(1.0 / 2.2));
+}
+
+@vertex
+fn main(Attributes a) -> Varyings {
+    vec3 normal = vec3(u_model * vec4(a.a_normal, 0.0));
+    gl_Position = u_mvp * vec4(a.a_pos, 1.0);
+    return Varyings(a.a_uv, normal);
+}
+
+@fragment
+fn main(Varyings v) -> FragmentOutput {
+    vec4 sample = texture(u_tex, v.v_uv);
+    if (sample.a < 0.1) {
+        discard;
+    }
+    return FragmentOutput(
+        vec4(gamma(sample.rgb * materials.u_mat.albedo), sample.a));
+}
+)axsl";
+
+static bool contains(const std::string &src, std::string_view needle) {
+  return src.find(needle) != std::string::npos;
+}
+
+static size_t count_occurrences(const std::string &src,
+                                std::string_view needle) {
+  size_t count = 0;
+  size_t position = 0;
+
+  while ((position = src.find(needle, position)) != std::string::npos) {
+    ++count;
+    position += needle.size();
+  }
+
+  return count;
+}
+
+static std::string errors_str(const CompileResult &r) {
+  std::string out;
+  for (const auto &e : r.errors) {
+    out += e;
+    out += '\n';
+  }
+  return out;
+}
+
+static std::string make_fragment_program(
+    std::string_view body, std::string_view globals = {},
+    std::string_view signature = "fn main() -> FragmentOutput",
+    std::string_view output_interface = R"axsl(
+interface FragmentOutput {
+    @location(0) vec4 color;
+}
+)axsl") {
+  std::string source = "@version 450;\n";
+
+  if (!globals.empty()) {
+    source += "\n";
+    source += globals;
+    if (source.back() != '\n') {
+      source += '\n';
+    }
+  }
+
+  if (!output_interface.empty()) {
+    source += "\n";
+    source += output_interface;
+    if (source.back() != '\n') {
+      source += '\n';
+    }
+  }
+
+  source += "\n@fragment\n";
+  source += signature;
+  source += " {\n";
+  source += body;
+  if (!body.empty() && body.back() != '\n') {
+    source += '\n';
+  }
+  source += "}\n";
+  return source;
+}
+
+TEST(ShaderCompiler, CompileSucceeds) {
+  Compiler compiler;
+  auto result = compiler.compile(k_full_source);
+  EXPECT_TRUE(result.ok()) << errors_str(result);
+  EXPECT_EQ(result.stages.size(), 2u);
+  EXPECT_NE(result.stages.find(StageKind::Vertex), result.stages.end());
+  EXPECT_NE(result.stages.find(StageKind::Fragment), result.stages.end());
+}
+
+TEST(ShaderCompiler, VersionHeader) {
+  Compiler compiler;
+  auto result = compiler.compile(k_full_source);
+  ASSERT_TRUE(result.ok()) << errors_str(result);
+  EXPECT_TRUE(
+      contains(result.stages.at(StageKind::Vertex), "#version 450 core"));
+  EXPECT_TRUE(
+      contains(result.stages.at(StageKind::Fragment), "#version 450 core"));
+}
+
+TEST(ShaderCompiler, ReachableGlobalStructEmittedPerStage) {
+  Compiler compiler;
+  auto result = compiler.compile(k_full_source);
+  ASSERT_TRUE(result.ok()) << errors_str(result);
+
+  EXPECT_FALSE(
+      contains(result.stages.at(StageKind::Vertex), "struct Material {"));
+  EXPECT_TRUE(
+      contains(result.stages.at(StageKind::Fragment), "struct Material {"));
+}
+
+TEST(ShaderCompiler, StructFieldInitializerEmitted) {
+  Compiler compiler;
+  auto src = make_fragment_program(R"axsl(
+    Material material;
+    return FragmentOutput(vec4(material.roughness));
+)axsl",
+                                   R"axsl(
+struct Material {
+    float roughness = 0.5;
+};
+)axsl");
+  auto result = compiler.compile(src);
+  ASSERT_TRUE(result.ok()) << errors_str(result);
+
+  EXPECT_TRUE(contains(result.stages.at(StageKind::Fragment),
+                       "float roughness = 0.5;"));
+}
+
+TEST(ShaderCompiler, IncludedStructFieldInitializerEmitted) {
+  Compiler compiler;
+
+  const std::filesystem::path include_dir =
+      std::filesystem::temp_directory_path() / "astralix-field-init-tests";
+  std::filesystem::create_directories(include_dir);
+
+  const std::filesystem::path include_path = include_dir / "material.axsl";
+  {
+    std::ofstream include_file(include_path);
+    include_file << R"axsl(
+struct Material {
+    float roughness = 0.5;
+};
+)axsl";
+  }
+
+  static constexpr std::string_view src = R"axsl(
+@version 450;
+@include "material.axsl";
+
+interface FragmentOutput {
+    @location(0) vec4 color;
+}
+
+@fragment
+fn main() -> FragmentOutput {
+    Material material;
+    return FragmentOutput(vec4(material.roughness));
+}
+)axsl";
+
+  auto result = compiler.compile(src, include_dir.string(), "main.axsl");
+  ASSERT_TRUE(result.ok()) << errors_str(result);
+
+  EXPECT_TRUE(contains(result.stages.at(StageKind::Fragment),
+                       "float roughness = 0.5;"));
+}
+
+TEST(ShaderCompiler, GlobalConstEmitted) {
+  Compiler compiler;
+  auto result = compiler.compile(k_full_source);
+  ASSERT_TRUE(result.ok()) << errors_str(result);
+  EXPECT_TRUE(contains(result.stages.at(StageKind::Vertex), "const float PI"));
+  EXPECT_TRUE(
+      contains(result.stages.at(StageKind::Fragment), "const float PI"));
+}
+
+TEST(ShaderCompiler, InterfaceBlockInlineEmitted) {
+  Compiler compiler;
+  auto result = compiler.compile(k_full_source);
+  ASSERT_TRUE(result.ok()) << errors_str(result);
+
+  EXPECT_TRUE(
+      contains(result.stages.at(StageKind::Vertex), "layout(location = 0) in"));
+  EXPECT_TRUE(contains(result.stages.at(StageKind::Fragment),
+                       "layout(location = 0) out vec4 _out_color;"));
+}
+
+TEST(ShaderCompiler, GlobalInterfaceResolvedInVertex) {
+  Compiler compiler;
+  auto result = compiler.compile(k_full_source);
+  ASSERT_TRUE(result.ok()) << errors_str(result);
+
+  const auto &vert = result.stages.at(StageKind::Vertex);
+  EXPECT_TRUE(contains(vert, "out Varyings {"));
+  EXPECT_TRUE(contains(vert, "vec2 v_uv;"));
+  EXPECT_TRUE(contains(vert, "vec3 v_normal;"));
+}
+
+TEST(ShaderCompiler, GlobalInterfaceResolvedInFragment) {
+  Compiler compiler;
+  auto result = compiler.compile(k_full_source);
+  ASSERT_TRUE(result.ok()) << errors_str(result);
+  const auto &frag = result.stages.at(StageKind::Fragment);
+  EXPECT_TRUE(contains(frag, "in Varyings {"));
+  EXPECT_TRUE(contains(frag, "vec2 v_uv;"));
+}
+
+TEST(ShaderCompiler, UniformEmitted) {
+  Compiler compiler;
+  auto result = compiler.compile(k_full_source);
+  ASSERT_TRUE(result.ok()) << errors_str(result);
+  EXPECT_TRUE(
+      contains(result.stages.at(StageKind::Vertex), "uniform mat4 u_mvp;"));
+  EXPECT_TRUE(contains(result.stages.at(StageKind::Fragment),
+                       "uniform sampler2D u_tex;"));
+  EXPECT_TRUE(contains(result.stages.at(StageKind::Fragment),
+                       "uniform MaterialBlock {"));
+}
+
+TEST(ShaderCompiler, BindingQualifierEmitted) {
+  Compiler compiler;
+  auto result = compiler.compile(k_full_source);
+  ASSERT_TRUE(result.ok()) << errors_str(result);
+  EXPECT_TRUE(
+      contains(result.stages.at(StageKind::Vertex), "layout(binding = 0)"));
+  EXPECT_TRUE(
+      contains(result.stages.at(StageKind::Fragment), "layout(binding = 3)"));
+}
+
+TEST(ShaderCompiler, BufferBlockBindingQualifierEmitted) {
+  Compiler compiler;
+  auto result = compiler.compile(k_full_source);
+  ASSERT_TRUE(result.ok()) << errors_str(result);
+  EXPECT_TRUE(contains(result.stages.at(StageKind::Fragment),
+                       "layout(binding = 2) uniform MaterialBlock {"));
+}
+
+TEST(ShaderCompiler, LocationQualifierOnField) {
+  Compiler compiler;
+  auto result = compiler.compile(k_full_source);
+  ASSERT_TRUE(result.ok()) << errors_str(result);
+  EXPECT_TRUE(
+      contains(result.stages.at(StageKind::Vertex), "layout(location = 0)"));
+  EXPECT_TRUE(
+      contains(result.stages.at(StageKind::Vertex), "layout(location = 1)"));
+}
+
+TEST(ShaderCompiler, StageIsolation) {
+  Compiler compiler;
+  auto result = compiler.compile(k_full_source);
+  ASSERT_TRUE(result.ok()) << errors_str(result);
+  EXPECT_FALSE(contains(result.stages.at(StageKind::Vertex), "u_tex"));
+  EXPECT_FALSE(contains(result.stages.at(StageKind::Vertex), "materials"));
+  EXPECT_FALSE(contains(result.stages.at(StageKind::Fragment), "u_mvp"));
+}
+
+TEST(ShaderCompiler, LexError) {
+  Compiler compiler;
+  auto result = compiler.compile("@version 450;\n@unknown");
+  EXPECT_FALSE(result.ok());
+  EXPECT_FALSE(result.errors.empty());
+}
+
+TEST(ShaderCompiler, ParseErrorUnclosedStage) {
+  Compiler compiler;
+  auto result = compiler.compile("@version 450;\n@vertex fn main() -> void {");
+  EXPECT_FALSE(result.ok());
+  EXPECT_FALSE(result.errors.empty());
+}
+
+TEST(ShaderCompiler, EmptySource) {
+  Compiler compiler;
+  auto result = compiler.compile("@version 450;");
+  EXPECT_TRUE(result.ok());
+  EXPECT_TRUE(result.stages.empty());
+}
+
+TEST(ShaderCompiler, UniformArray) {
+  Compiler compiler;
+  auto src = make_fragment_program(R"axsl(
+    return FragmentOutput(vec4(point_lights[0].position, 1.0));
+)axsl",
+                                   R"axsl(
+struct PointLight { vec3 position; };
+uniform PointLight point_lights[4];
+)axsl");
+  auto result = compiler.compile(src);
+  ASSERT_TRUE(result.ok()) << errors_str(result);
+  EXPECT_TRUE(contains(result.stages.at(StageKind::Fragment),
+                       "uniform PointLight point_lights[4]"));
+}
+
+TEST(ShaderCompiler, WhileLoop) {
+  Compiler compiler;
+  auto src = make_fragment_program(R"axsl(
+    float x = 0.0;
+    while (x < 1.0) { x += 0.1; }
+    return FragmentOutput(vec4(x, x, x, 1.0));
+)axsl");
+  auto result = compiler.compile(src);
+  ASSERT_TRUE(result.ok()) << errors_str(result);
+  EXPECT_TRUE(contains(result.stages.at(StageKind::Fragment), "while ("));
+}
+
+TEST(ShaderCompiler, LocalVarDecl) {
+  Compiler compiler;
+  auto src = make_fragment_program(R"axsl(
+    vec4 sample = vec4(1.0, 0.0, 0.0, 1.0);
+    return FragmentOutput(sample);
+)axsl");
+  auto result = compiler.compile(src);
+  ASSERT_TRUE(result.ok()) << errors_str(result);
+  EXPECT_TRUE(contains(result.stages.at(StageKind::Fragment), "vec4 sample"));
+}
+
+TEST(ShaderCompiler, ForLoopInit) {
+  Compiler compiler;
+  auto src = make_fragment_program(R"axsl(
+    float r = 0.0;
+    for (int i = 0; i < 4; ++i) { r += 0.25; }
+    return FragmentOutput(vec4(r, r, r, 1.0));
+)axsl");
+  auto result = compiler.compile(src);
+  ASSERT_TRUE(result.ok()) << errors_str(result);
+  EXPECT_TRUE(contains(result.stages.at(StageKind::Fragment), "int i = 0"));
+}
+
+TEST(ShaderCompiler, ConstLocalVar) {
+  Compiler compiler;
+  auto src = make_fragment_program(R"axsl(
+    const float scale = 2.0;
+    return FragmentOutput(vec4(scale));
+)axsl");
+  auto result = compiler.compile(src);
+  ASSERT_TRUE(result.ok()) << errors_str(result);
+  EXPECT_TRUE(
+      contains(result.stages.at(StageKind::Fragment), "const float scale"));
+}
+
+static size_t count_substr(const std::string &src, std::string_view needle) {
+  size_t count = 0, pos = 0;
+  while ((pos = src.find(needle, pos)) != std::string::npos) {
+    ++count;
+    pos += needle.size();
+  }
+  return count;
+}
+
+TEST(ShaderCompiler, TrailingDotFloat) {
+  Compiler compiler;
+  auto src = make_fragment_program(R"axsl(
+    float a = 0.;
+    float b = 1.;
+    float c = 2.;
+    return FragmentOutput(vec4(a + b + c));
+)axsl");
+
+  auto result = compiler.compile(src);
+
+  ASSERT_TRUE(result.ok()) << errors_str(result);
+
+  const auto &fragment = result.stages.at(StageKind::Fragment);
+
+  EXPECT_TRUE(contains(fragment, "float a"));
+  EXPECT_TRUE(contains(fragment, "float b"));
+  EXPECT_TRUE(contains(fragment, "float c"));
+}
+
+TEST(ShaderCompiler, TernaryExpression) {
+  Compiler compiler;
+  auto src = make_fragment_program(R"axsl(
+    float a = 1.0;
+    float x = (a > 0.) ? 1. : 0.;
+    return FragmentOutput(vec4(x));
+)axsl");
+  auto result = compiler.compile(src);
+  ASSERT_TRUE(result.ok()) << errors_str(result);
+  EXPECT_TRUE(contains(result.stages.at(StageKind::Fragment), "? 1"));
+}
+
+TEST(ShaderCompiler, UniformBlock) {
+  Compiler compiler;
+  auto src = make_fragment_program(R"axsl(
+    mat4 model = instance.models[0];
+    return FragmentOutput(vec4(model[0][0]));
+)axsl",
+                                   R"axsl(
+@binding(0) uniform InstanceBuffer { mat4 models[]; } instance;
+)axsl");
+  auto result = compiler.compile(src);
+  ASSERT_TRUE(result.ok()) << errors_str(result);
+  const auto &frag = result.stages.at(StageKind::Fragment);
+  EXPECT_TRUE(contains(frag, "layout(binding = 0) uniform InstanceBuffer {"));
+  EXPECT_TRUE(contains(frag, "mat4 models[];"));
+  EXPECT_TRUE(contains(frag, "} instance;"));
+}
+
+TEST(ShaderCompiler, InlineInterfaceStorageBlockEmitted) {
+  Compiler compiler;
+  auto src = make_fragment_program(R"axsl(
+    mat4 model = instance.models[0];
+    return FragmentOutput(vec4(model[0][0]));
+)axsl",
+                                   R"axsl(
+@std430
+@binding(0)
+in InstanceBuffer {
+    mat4 models[];
+} instance;
+)axsl");
+  auto result = compiler.compile(src);
+  ASSERT_TRUE(result.ok()) << errors_str(result);
+  const auto &frag = result.stages.at(StageKind::Fragment);
+  EXPECT_TRUE(
+      contains(frag, "layout(std430, binding = 0) buffer InstanceBuffer {"));
+  EXPECT_TRUE(contains(frag, "mat4 models[];"));
+  EXPECT_TRUE(contains(frag, "} instance;"));
+}
+
+TEST(ShaderCompiler, UniformWithDefault) {
+  Compiler compiler;
+  auto src = make_fragment_program(R"axsl(
+      return FragmentOutput(flag ? vec4(near_plane) : vec4(0.0));
+)axsl",
+                                   R"axsl(
+uniform float near_plane = -10.0;
+uniform bool flag = false;
+)axsl");
+  auto result = compiler.compile(src);
+  ASSERT_TRUE(result.ok()) << errors_str(result);
+  const auto &frag = result.stages.at(StageKind::Fragment);
+  EXPECT_TRUE(contains(frag, "uniform float near_plane = "));
+  EXPECT_TRUE(contains(frag, "uniform bool flag = false"));
+}
+
+TEST(ShaderCompiler, NestedForLoops) {
+  Compiler compiler;
+  auto src = make_fragment_program(R"axsl(
+      float sum = 0.0;
+      for (int x = -1; x <= 1; ++x) {
+          for (int y = -1; y <= 1; ++y) {
+              float v = 0.;
+              sum += v;
+          }
+      }
+      return FragmentOutput(vec4(sum));
+)axsl");
+  auto result = compiler.compile(src);
+  ASSERT_TRUE(result.ok()) << errors_str(result);
+  EXPECT_GE(count_substr(result.stages.at(StageKind::Fragment), "for ("), 2u);
+}
+
+TEST(ShaderCompiler, BreakContinue) {
+  Compiler compiler;
+  auto src = make_fragment_program(R"axsl(
+  float r = 0.0;
+  for (int i = 0; i < 4; ++i) {
+      if (i == 2) { break; }
+      continue;
+  }
+  return FragmentOutput(vec4(r));
+)axsl");
+  auto result = compiler.compile(src);
+  ASSERT_TRUE(result.ok()) << errors_str(result);
+  const auto &frag = result.stages.at(StageKind::Fragment);
+  EXPECT_TRUE(contains(frag, "break;"));
+  EXPECT_TRUE(contains(frag, "continue;"));
+}
+
+TEST(ShaderCompiler, DiscardStatement) {
+  Compiler compiler;
+  auto src = make_fragment_program(R"axsl(
+  float alpha = 0.5;
+
+  if (alpha < 0.1) {
+      discard;
+  }
+
+  return FragmentOutput(vec4(1.0));
+)axsl");
+  auto result = compiler.compile(src);
+  ASSERT_TRUE(result.ok()) << errors_str(result);
+  EXPECT_TRUE(contains(result.stages.at(StageKind::Fragment), "discard;"));
+}
+
+TEST(ShaderCompiler, ArrayIndexing) {
+  Compiler compiler;
+  auto src = make_fragment_program(R"axsl(
+    vec3 v = lights[0].position;
+    return FragmentOutput(vec4(v, 1.0));
+)axsl",
+                                   R"axsl(
+struct PointLight { vec3 position; };
+uniform PointLight lights[4];
+)axsl");
+  auto result = compiler.compile(src);
+  ASSERT_TRUE(result.ok()) << errors_str(result);
+  EXPECT_TRUE(contains(result.stages.at(StageKind::Fragment), "lights[0]"));
+}
+
+TEST(ShaderCompiler, CompoundAssignment) {
+  Compiler compiler;
+  auto src = make_fragment_program(R"axsl(
+    float x = 0.;
+    x += 1.;
+    x -= 0.5;
+    x *= 2.;
+    return FragmentOutput(vec4(x));
+)axsl");
+  auto result = compiler.compile(src);
+  ASSERT_TRUE(result.ok()) << errors_str(result);
+  const auto &frag = result.stages.at(StageKind::Fragment);
+  EXPECT_TRUE(contains(frag, "+="));
+  EXPECT_TRUE(contains(frag, "-="));
+  EXPECT_TRUE(contains(frag, "*="));
+}
+
+TEST(ShaderCompiler, OutInterfaceBlockWithLocations) {
+  Compiler compiler;
+  auto src = make_fragment_program(
+      R"axsl(
+    return FragOut(vec4(1.0), vec4(0.0));
+)axsl",
+      {}, "fn main() -> FragOut", R"axsl(
+interface FragOut {
+    @location(0) vec4 color;
+    @location(1) vec4 bright;
+}
+)axsl");
+  auto result = compiler.compile(src);
+  ASSERT_TRUE(result.ok()) << errors_str(result);
+  const auto &frag = result.stages.at(StageKind::Fragment);
+  EXPECT_TRUE(contains(frag, "layout(location = 0) out vec4 _out_color"));
+  EXPECT_TRUE(contains(frag, "layout(location = 1) out vec4 _out_bright"));
+}
+
+TEST(ShaderCompiler, UndefinedVariableError) {
+  Compiler compiler;
+  static constexpr std::string_view src = R"axsl(
+@version 450;
+interface FragmentOutput {
+    @location(0) vec4 color;
+}
+
+@fragment
+fn main() -> FragmentOutput {
+    vec3 pos = undefined_var.position;
+    return FragmentOutput(vec4(pos, 1.0));
+}
+)axsl";
+  auto result = compiler.compile(src);
+  EXPECT_FALSE(result.ok());
+  EXPECT_FALSE(result.errors.empty());
+  const auto err = errors_str(result);
+  EXPECT_TRUE(err.find("undefined identifier") != std::string::npos);
+  EXPECT_TRUE(err.find("undefined_var") != std::string::npos)
+      << "Expected identifier name in error: " << err;
+}
+
+TEST(ShaderCompiler, LocalVariableReference) {
+  Compiler compiler;
+  auto src = make_fragment_program(R"axsl(
+    Material material;
+    material.albedo = vec3(1.0, 0.5, 0.2);
+    return FragmentOutput(vec4(material.albedo, 1.0));
+)axsl",
+                                   R"axsl(
+struct Material { vec3 albedo; float roughness; };
+)axsl");
+  auto result = compiler.compile(src);
+  ASSERT_TRUE(result.ok()) << errors_str(result);
+  EXPECT_TRUE(
+      contains(result.stages.at(StageKind::Fragment), "material.albedo"));
+}
+
+TEST(ShaderCompiler, StageFunctionParameterReference) {
+  Compiler compiler;
+  static constexpr std::string_view src = R"axsl(
+@version 450;
+
+interface VertexOutput {
+    @location(0) vec3 texture_coordinate;
+}
+
+interface FragmentInput {
+    @uniform samplerCube skybox;
+}
+
+interface FragmentOutput {
+    @location(0) vec4 color;
+}
+
+@fragment
+fn main(VertexOutput vertex, FragmentInput fragment) -> void {
+    vec4 color = texture(fragment.skybox, vertex.texture_coordinate);
+    return FragmentOutput(color);
+}
+)axsl";
+  auto result = compiler.compile(src);
+  ASSERT_TRUE(result.ok()) << errors_str(result);
+  const auto &frag = result.stages.at(StageKind::Fragment);
+  EXPECT_TRUE(contains(frag, "in VertexOutput {"));
+  EXPECT_TRUE(contains(frag, "uniform samplerCube _skybox;"));
+  EXPECT_TRUE(contains(frag, "layout(location = 0) out vec4 _out_color;"));
+  EXPECT_TRUE(contains(frag, "texture(_skybox, vertex.texture_coordinate)"));
+  EXPECT_TRUE(contains(frag, "_out_color = color;"));
+  EXPECT_TRUE(contains(frag, "vertex.texture_coordinate"));
+}
+
+TEST(ShaderCompiler, VertexStageFunctionParameterReference) {
+  Compiler compiler;
+  static constexpr std::string_view src = R"axsl(
+@version 450;
+
+uniform mat4 view_without_transformation;
+uniform mat4 projection;
+
+@in
+interface VertexInput {
+    @location(0) vec3 position;
+}
+
+interface VertexOutput {
+    @location(0) vec3 texture_coordinate;
+}
+
+@vertex
+fn main(VertexInput input) -> VertexOutput {
+    vec4 pos = projection * view_without_transformation * vec4(input.position, 1.);
+    gl_Position = pos.xyww;
+    return VertexOutput(input.position);
+}
+)axsl";
+  auto result = compiler.compile(src);
+  ASSERT_TRUE(result.ok()) << errors_str(result);
+  const auto &vert = result.stages.at(StageKind::Vertex);
+  EXPECT_TRUE(contains(vert, "layout(location = 0) in vec3 position;"));
+  EXPECT_FALSE(contains(vert, "in VertexInput {"));
+  EXPECT_TRUE(contains(vert, "_stage_out.texture_coordinate = position;"));
+}
+
+TEST(ShaderCompiler, InterfaceFieldInitializerAppliedToVertexOutput) {
+  Compiler compiler;
+  static constexpr std::string_view src = R"axsl(
+@version 450;
+
+interface VertexOutput {
+    @location(0) vec3 texture_coordinate = vec3(0.0);
+}
+
+@vertex
+fn main() -> VertexOutput {
+    gl_Position = vec4(0.0, 0.0, 0.0, 1.0);
+    return VertexOutput();
+}
+)axsl";
+  auto result = compiler.compile(src);
+  ASSERT_TRUE(result.ok()) << errors_str(result);
+
+  const auto &vert = result.stages.at(StageKind::Vertex);
+  EXPECT_TRUE(contains(vert, "out VertexOutput {"));
+  EXPECT_TRUE(contains(vert, "layout(location = 0) vec3 texture_coordinate;"));
+  EXPECT_FALSE(
+      contains(vert, "layout(location = 0) vec3 texture_coordinate = vec3"));
+  EXPECT_TRUE(contains(vert, "_stage_out.texture_coordinate = vec3(0);"));
+  EXPECT_FALSE(contains(vert, "return VertexOutput();"));
+  EXPECT_TRUE(contains(vert, "return;"));
+}
+
+TEST(ShaderCompiler, StructuredReturnDoesNotDuplicateOutputDefaults) {
+  Compiler compiler;
+  static constexpr std::string_view src = R"axsl(
+@version 450;
+
+uniform samplerCube skybox;
+
+@in
+interface VertexInput {
+    @location(0) vec3 position;
+    @location(2) vec3 texture_coordinate;
+}
+
+interface FragmentOutput {
+    @location(0) vec4 color;
+    @location(1) float test = 0.0;
+    @location(2) bool has_value = true;
+}
+
+@fragment
+fn main(VertexInput input) -> FragmentOutput {
+    vec4 color = texture(skybox, input.texture_coordinate);
+    return FragmentOutput(color);
+}
+)axsl";
+  auto result = compiler.compile(src);
+  ASSERT_TRUE(result.ok()) << errors_str(result);
+
+  const auto &frag = result.stages.at(StageKind::Fragment);
+  EXPECT_EQ(count_occurrences(frag, "_out_test = 0;"), 1u);
+  EXPECT_EQ(count_occurrences(frag, "_out_has_value = true;"), 1u);
+  EXPECT_EQ(count_occurrences(frag, "_out_color = color;"), 1u);
+}
+
+TEST(ShaderCompiler, VertexOutputAccumulatorLocalLowersToStageOutput) {
+  Compiler compiler;
+  static constexpr std::string_view src = R"axsl(
+@version 450;
+
+@in
+interface VertexInput {
+    @location(0) vec3 position;
+}
+
+interface VertexOutput {
+    @location(0) vec3 world_position;
+}
+
+@vertex
+fn main(VertexInput input) -> VertexOutput {
+    VertexOutput output;
+    output.world_position = input.position;
+    gl_Position = vec4(input.position, 1.0);
+    return output;
+}
+)axsl";
+  auto result = compiler.compile(src);
+  ASSERT_TRUE(result.ok()) << errors_str(result);
+
+  const auto &vert = result.stages.at(StageKind::Vertex);
+  EXPECT_TRUE(contains(vert, "out VertexOutput {"));
+  EXPECT_TRUE(contains(vert, "} output;"));
+  EXPECT_FALSE(contains(vert, "VertexOutput output;"));
+  EXPECT_TRUE(contains(vert, "output.world_position = position;"));
+  EXPECT_FALSE(contains(vert, "return output;"));
+  EXPECT_TRUE(contains(vert, "return;"));
+}
+
+TEST(ShaderCompiler, FragmentOutputAccumulatorLocalLowersToSplitOutputs) {
+  Compiler compiler;
+  static constexpr std::string_view src = R"axsl(
+@version 450;
+
+interface VertexOutput {
+    @location(0) vec2 texture_coordinate;
+}
+
+interface FragmentOutput {
+    @location(0) vec4 color;
+    @location(1) float brightness = 0.0;
+}
+
+@fragment
+fn main(VertexOutput input) -> FragmentOutput {
+    FragmentOutput output;
+    output.color = vec4(input.texture_coordinate, 0.0, 1.0);
+    output.brightness = output.color.r;
+    return output;
+}
+)axsl";
+  auto result = compiler.compile(src);
+  ASSERT_TRUE(result.ok()) << errors_str(result);
+
+  const auto &frag = result.stages.at(StageKind::Fragment);
+  EXPECT_TRUE(contains(frag, "layout(location = 0) out vec4 _out_color;"));
+  EXPECT_TRUE(
+      contains(frag, "layout(location = 1) out float _out_brightness;"));
+  EXPECT_FALSE(contains(frag, "FragmentOutput output;"));
+  EXPECT_TRUE(
+      contains(frag, "_out_color = vec4(input.texture_coordinate, 0, 1);"));
+  EXPECT_TRUE(contains(frag, "_out_brightness = _out_color.r;"));
+  EXPECT_FALSE(contains(frag, "return output;"));
+  EXPECT_TRUE(contains(frag, "return;"));
+}
+
+TEST(ShaderCompiler, OutputAccumulatorRejectsMultipleLocals) {
+  Compiler compiler;
+  static constexpr std::string_view src = R"axsl(
+@version 450;
+
+interface VertexOutput {
+    @location(0) vec3 world_position;
+}
+
+@vertex
+fn main() -> VertexOutput {
+    VertexOutput output;
+    VertexOutput other;
+    gl_Position = vec4(0.0, 0.0, 0.0, 1.0);
+    return output;
+}
+)axsl";
+  auto result = compiler.compile(src);
+  ASSERT_FALSE(result.ok());
+  const auto err = errors_str(result);
+  EXPECT_NE(err.find("supports only one local of type 'VertexOutput'"),
+            std::string::npos)
+      << err;
+}
+
+TEST(ShaderCompiler, OutputAccumulatorRejectsInitializer) {
+  Compiler compiler;
+  static constexpr std::string_view src = R"axsl(
+@version 450;
+
+interface VertexOutput {
+    @location(0) vec3 world_position;
+}
+
+@vertex
+fn main() -> VertexOutput {
+    VertexOutput output = VertexOutput(vec3(1.0));
+    gl_Position = vec4(0.0, 0.0, 0.0, 1.0);
+    return output;
+}
+)axsl";
+  auto result = compiler.compile(src);
+  ASSERT_FALSE(result.ok());
+  const auto err = errors_str(result);
+  EXPECT_NE(
+      err.find(
+          "stage entry output accumulator 'output' cannot have an initializer"),
+      std::string::npos)
+      << err;
+}
+
+TEST(ShaderCompiler, OutputAccumulatorRejectsWholeValueAssignment) {
+  Compiler compiler;
+  static constexpr std::string_view src = R"axsl(
+@version 450;
+
+interface VertexOutput {
+    @location(0) vec3 world_position;
+}
+
+@vertex
+fn main() -> VertexOutput {
+    VertexOutput output;
+    output = VertexOutput(vec3(1.0));
+    gl_Position = vec4(0.0, 0.0, 0.0, 1.0);
+    return output;
+}
+)axsl";
+  auto result = compiler.compile(src);
+  ASSERT_FALSE(result.ok());
+  const auto err = errors_str(result);
+  EXPECT_NE(err.find("stage entry output accumulator 'output' cannot be "
+                     "assigned as a whole value"),
+            std::string::npos)
+      << err;
+}
+
+TEST(ShaderCompiler, OutputAccumulatorRejectsReturningDifferentLocal) {
+  Compiler compiler;
+  static constexpr std::string_view src = R"axsl(
+@version 450;
+
+interface VertexOutput {
+    @location(0) vec3 world_position;
+}
+
+@vertex
+fn main() -> VertexOutput {
+    VertexOutput output;
+    VertexOutput other;
+    gl_Position = vec4(0.0, 0.0, 0.0, 1.0);
+    return other;
+}
+)axsl";
+  auto result = compiler.compile(src);
+  ASSERT_FALSE(result.ok());
+  const auto err = errors_str(result);
+  EXPECT_NE(
+      err.find(
+          "stage entry output accumulator must return 'output', not 'other'"),
+      std::string::npos)
+      << err;
+}
+
+TEST(ShaderCompiler, OutputAccumulatorRejectsNonFieldValueUse) {
+  Compiler compiler;
+  static constexpr std::string_view src = R"axsl(
+@version 450;
+
+interface VertexOutput {
+    @location(0) vec3 world_position;
+}
+
+@vertex
+fn main() -> VertexOutput {
+    VertexOutput output;
+    int value = output;
+    gl_Position = vec4(float(value), 0.0, 0.0, 1.0);
+    return output;
+}
+)axsl";
+  auto result = compiler.compile(src);
+  ASSERT_FALSE(result.ok());
+  const auto err = errors_str(result);
+  EXPECT_NE(err.find("stage entry output accumulator 'output' can only be used "
+                     "via field access or 'return output'"),
+            std::string::npos)
+      << err;
+}
+
+TEST(ShaderCompiler, ForwardDeclaresGlobalFunctions) {
+  Compiler compiler;
+  auto src = make_fragment_program(R"axsl(
+    return FragmentOutput(vec4(call_first(1.0)));
+)axsl",
+                                   R"axsl(
+fn call_first(float x) -> float {
+    return later(x);
+}
+
+fn later(float x) -> float {
+    return x * 2.0;
+}
+)axsl");
+  auto result = compiler.compile(src);
+  ASSERT_TRUE(result.ok()) << errors_str(result);
+
+  const auto &frag = result.stages.at(StageKind::Fragment);
+  auto later_proto = frag.find("float later(float x);");
+  auto later_def = frag.find("float later(float x) {");
+  ASSERT_NE(later_proto, std::string::npos) << frag;
+  ASSERT_NE(later_def, std::string::npos) << frag;
+  EXPECT_LT(later_proto, later_def);
+}
+
+TEST(ShaderCompiler, IncludedFunctionsAreForwardDeclared) {
+  Compiler compiler;
+
+  const std::filesystem::path include_dir =
+      std::filesystem::temp_directory_path() / "astralix-forward-decl-tests";
+  std::filesystem::create_directories(include_dir);
+
+  const std::filesystem::path include_path = include_dir / "later.axsl";
+  {
+    std::ofstream include_file(include_path);
+    include_file << R"axsl(
+fn later(float x) -> float {
+    return x * 2.0;
+}
+)axsl";
+  }
+
+  static constexpr std::string_view src = R"axsl(
+@version 450;
+@include "later.axsl";
+
+interface FragmentOutput {
+    @location(0) vec4 color;
+}
+
+fn call_first(float x) -> float {
+    return later(x);
+}
+
+@fragment
+fn main() -> FragmentOutput {
+    return FragmentOutput(vec4(call_first(1.0)));
+}
+)axsl";
+
+  auto result = compiler.compile(src, include_dir.string(), "main.axsl");
+  ASSERT_TRUE(result.ok()) << errors_str(result);
+
+  const auto &frag = result.stages.at(StageKind::Fragment);
+  auto later_proto = frag.find("float later(float x);");
+  auto later_def = frag.find("float later(float x) {");
+  ASSERT_NE(later_proto, std::string::npos) << frag;
+  ASSERT_NE(later_def, std::string::npos) << frag;
+  EXPECT_LT(later_proto, later_def);
+}
+
+TEST(ShaderCompiler, StageOnlyEmitsReachableGlobalFunctions) {
+  Compiler compiler;
+  static constexpr std::string_view src = R"axsl(
+@version 450;
+
+interface FragmentOutput {
+    @location(0) vec4 color;
+}
+
+fn fragment_helper(float x) -> float {
+    return fragment_leaf(x);
+}
+
+fn fragment_leaf(float x) -> float {
+    return x * 2.0;
+}
+
+@vertex
+fn main() -> void {
+    gl_Position = vec4(0.0, 0.0, 0.0, 1.0);
+}
+
+@fragment
+fn main() -> FragmentOutput {
+    return FragmentOutput(vec4(fragment_helper(1.0)));
+}
+)axsl";
+  auto result = compiler.compile(src);
+  ASSERT_TRUE(result.ok()) << errors_str(result);
+
+  const auto &vert = result.stages.at(StageKind::Vertex);
+  EXPECT_FALSE(contains(vert, "float fragment_helper(float x);"));
+  EXPECT_FALSE(contains(vert, "float fragment_helper(float x) {"));
+  EXPECT_FALSE(contains(vert, "float fragment_leaf(float x);"));
+  EXPECT_FALSE(contains(vert, "float fragment_leaf(float x) {"));
+
+  const auto &frag = result.stages.at(StageKind::Fragment);
+  EXPECT_TRUE(contains(frag, "float fragment_helper(float x);"));
+  EXPECT_TRUE(contains(frag, "float fragment_helper(float x) {"));
+  EXPECT_TRUE(contains(frag, "float fragment_leaf(float x);"));
+  EXPECT_TRUE(contains(frag, "float fragment_leaf(float x) {"));
+}
+
+TEST(ShaderCompiler, StageOnlyEmitsReachableStructs) {
+  Compiler compiler;
+  static constexpr std::string_view src = R"axsl(
+@version 450;
+
+struct LightExposure {
+    vec3 ambient;
+    vec3 diffuse;
+    vec3 specular;
+};
+
+struct DirectionalLight {
+    LightExposure exposure;
+    vec3 direction;
+};
+
+struct PointLight {
+    vec3 position;
+    LightExposure exposure;
+};
+
+uniform DirectionalLight directional_light;
+uniform PointLight point_light;
+
+interface FragmentOutput {
+    @location(0) vec4 color;
+}
+
+@vertex
+fn main() -> void {
+    gl_Position = vec4(directional_light.exposure.ambient, 1.0);
+}
+
+@fragment
+fn main() -> FragmentOutput {
+    return FragmentOutput(vec4(point_light.exposure.diffuse, 1.0));
+}
+)axsl";
+  auto result = compiler.compile(src);
+  ASSERT_TRUE(result.ok()) << errors_str(result);
+
+  const auto &vert = result.stages.at(StageKind::Vertex);
+  EXPECT_TRUE(contains(vert, "struct LightExposure {"));
+  EXPECT_TRUE(contains(vert, "struct DirectionalLight {"));
+  EXPECT_FALSE(contains(vert, "struct PointLight {"));
+
+  const auto &frag = result.stages.at(StageKind::Fragment);
+  EXPECT_TRUE(contains(frag, "struct LightExposure {"));
+  EXPECT_TRUE(contains(frag, "struct PointLight {"));
+}
+
+TEST(ShaderCompiler, BuiltInVariableReference) {
+  Compiler compiler;
+  static constexpr std::string_view src = R"axsl(
+@version 450;
+interface FragmentOutput {
+    @location(0) vec4 color;
+}
+
+@vertex
+fn main() -> void {
+    gl_Position = vec4(0.0, 0.0, 0.0, 1.0);
+}
+
+@fragment
+fn main() -> FragmentOutput {
+    vec4 coord = gl_FragCoord;
+    return FragmentOutput(coord);
+}
+)axsl";
+  auto result = compiler.compile(src);
+  ASSERT_TRUE(result.ok()) << errors_str(result);
+  EXPECT_TRUE(contains(result.stages.at(StageKind::Vertex), "gl_Position"));
+  EXPECT_TRUE(contains(result.stages.at(StageKind::Fragment), "gl_FragCoord"));
+}
+
+TEST(ShaderCompiler, UniformArrayReference) {
+  Compiler compiler;
+  auto src = make_fragment_program(R"axsl(
+    vec3 light_pos = lights[0].position;
+    return FragmentOutput(vec4(light_pos, 1.0));
+)axsl",
+                                   R"axsl(
+struct PointLight { vec3 position; vec3 color; };
+uniform PointLight lights[4];
+)axsl");
+  auto result = compiler.compile(src);
+  ASSERT_TRUE(result.ok()) << errors_str(result);
+  EXPECT_TRUE(contains(result.stages.at(StageKind::Fragment), "lights[0]"));
+}
+
+TEST(ShaderCompiler, InterfaceBlockInstanceValidation) {
+  Compiler compiler;
+  static constexpr std::string_view src = R"axsl(
+@version 450;
+
+interface Coords {
+    vec2 uv;
+    vec4 light_space_pos;
+}
+
+interface FragmentOutput {
+    @location(0) vec4 color;
+}
+
+@fragment
+fn main(Coords obj_coordinates) -> FragmentOutput {
+    vec4 pos = obj_coordinates.light_space_pos;
+    return FragmentOutput(pos);
+}
+)axsl";
+  auto result = compiler.compile(src);
+  ASSERT_TRUE(result.ok()) << errors_str(result);
+  EXPECT_TRUE(
+      contains(result.stages.at(StageKind::Fragment), "obj_coordinates"));
+}
+
+TEST(ShaderCompiler, GlobalInlineInterfaceInstanceReference) {
+  Compiler compiler;
+  static constexpr std::string_view src = R"axsl(
+@version 450;
+
+in Test {
+    @location(1) vec3 a;
+} test;
+
+interface FragmentOutput {
+    @location(0) vec4 color;
+}
+
+@fragment
+fn main() -> FragmentOutput {
+    return FragmentOutput(vec4(test.a, 1.0));
+}
+)axsl";
+  auto result = compiler.compile(src);
+  ASSERT_TRUE(result.ok()) << errors_str(result);
+
+  const auto &frag = result.stages.at(StageKind::Fragment);
+  EXPECT_TRUE(contains(frag, "in Test {"));
+  EXPECT_TRUE(contains(frag, "} test;"));
+  EXPECT_TRUE(contains(frag, "test.a"));
+}
+
+TEST(ShaderCompiler, MixedSymbolSourcesResolve) {
+  Compiler compiler;
+  static constexpr std::string_view src = R"axsl(
+@version 450;
+
+uniform float exposure;
+
+interface VertexOutput {
+    @location(0) vec3 texture_coordinate;
+}
+
+interface FragmentResources {
+    @uniform samplerCube skybox;
+}
+
+in Test {
+    @location(1) vec3 tint;
+} test;
+
+interface FragmentOutput {
+    @location(0) vec4 color;
+}
+
+@fragment
+fn main(VertexOutput vertex, FragmentResources fragment) -> FragmentOutput {
+    vec4 sample = texture(fragment.skybox, vertex.texture_coordinate);
+    return FragmentOutput(vec4(sample.rgb * exposure + test.tint, sample.a));
+}
+)axsl";
+  auto result = compiler.compile(src);
+  ASSERT_TRUE(result.ok()) << errors_str(result);
+
+  const auto &frag = result.stages.at(StageKind::Fragment);
+  EXPECT_TRUE(contains(frag, "uniform float exposure"));
+  EXPECT_TRUE(contains(frag, "uniform samplerCube _skybox"));
+  EXPECT_TRUE(contains(frag, "in Test {"));
+  EXPECT_TRUE(contains(frag, "} test;"));
+  EXPECT_TRUE(contains(frag, "texture(_skybox, vertex.texture_coordinate)"));
+  EXPECT_TRUE(contains(frag, "test.tint"));
+}
+
+TEST(ShaderCompiler, UniformInterfaceRoleOnStageParamCullsUnusedFields) {
+  Compiler compiler;
+  static constexpr std::string_view src = R"axsl(
+@version 450;
+
+@uniform
+interface Entity {
+    mat4 view;
+    mat4 projection;
+    mat4 g_model;
+    mat4 light_space_matrix;
+    bool use_instacing = false;
+    float unused_scale = 2.0;
+}
+
+@vertex
+fn main(Entity entity) -> void {
+    gl_Position = entity.projection * entity.view * vec4(0.0, 0.0, 0.0, 1.0);
+    if (entity.use_instacing) {
+        gl_Position = entity.g_model * gl_Position;
+    }
+}
+)axsl";
+  auto result = compiler.compile(src);
+  ASSERT_TRUE(result.ok()) << errors_str(result);
+
+  const auto &vert = result.stages.at(StageKind::Vertex);
+  EXPECT_FALSE(contains(vert, "in Entity {"));
+  EXPECT_TRUE(contains(vert, "uniform mat4 _view;"));
+  EXPECT_TRUE(contains(vert, "uniform mat4 _projection;"));
+  EXPECT_TRUE(contains(vert, "uniform mat4 _g_model;"));
+  EXPECT_TRUE(contains(vert, "uniform bool _use_instacing = false;"));
+  EXPECT_FALSE(contains(vert, "_light_space_matrix"));
+  EXPECT_FALSE(contains(vert, "_unused_scale"));
+  EXPECT_TRUE(contains(
+      vert, "gl_Position = (_projection * _view) * vec4(0, 0, 0, 1);"));
+  EXPECT_TRUE(contains(vert, "if (_use_instacing)"));
+  EXPECT_TRUE(contains(vert, "gl_Position = _g_model * gl_Position;"));
+}
+
+TEST(ShaderCompiler, FieldAnnotatedResourceParamCullsUnusedFields) {
+  Compiler compiler;
+  static constexpr std::string_view src = R"axsl(
+@version 450;
+
+interface VertexOutput {
+    @location(0) vec3 texture_coordinate;
+}
+
+interface FragmentResources {
+    @uniform samplerCube skybox;
+    @uniform float exposure = 1.0;
+}
+
+interface FragmentOutput {
+    @location(0) vec4 color;
+}
+
+@fragment
+fn main(VertexOutput vertex, FragmentResources fragment) -> FragmentOutput {
+    vec4 sample = texture(fragment.skybox, vertex.texture_coordinate);
+    return FragmentOutput(sample);
+}
+)axsl";
+  auto result = compiler.compile(src);
+  ASSERT_TRUE(result.ok()) << errors_str(result);
+
+  const auto &frag = result.stages.at(StageKind::Fragment);
+  EXPECT_TRUE(contains(frag, "uniform samplerCube _skybox;"));
+  EXPECT_FALSE(contains(frag, "_exposure"));
+  EXPECT_TRUE(contains(frag, "texture(_skybox, vertex.texture_coordinate)"));
+}
+
+TEST(ShaderCompiler, NestedResourceFieldUseKeepsBaseFieldEmitted) {
+  Compiler compiler;
+  static constexpr std::string_view src = R"axsl(
+@version 450;
+
+struct Material {
+    sampler2D diffuse;
+    sampler2D specular;
+};
+
+interface VertexOutput {
+    @location(0) vec2 texture_coordinate;
+}
+
+interface FragmentResources {
+    @uniform Material materials[1];
+    @uniform float unused_strength = 1.0;
+}
+
+interface FragmentOutput {
+    @location(0) vec4 color;
+}
+
+@fragment
+fn main(VertexOutput vertex, FragmentResources fragment) -> FragmentOutput {
+    vec4 sample = texture(fragment.materials[0].diffuse, vertex.texture_coordinate);
+    return FragmentOutput(sample);
+}
+)axsl";
+  auto result = compiler.compile(src);
+  ASSERT_TRUE(result.ok()) << errors_str(result);
+
+  const auto &frag = result.stages.at(StageKind::Fragment);
+  EXPECT_TRUE(contains(frag, "uniform Material _materials[1];"));
+  EXPECT_FALSE(contains(frag, "_unused_strength"));
+  EXPECT_TRUE(contains(
+      frag, "texture(_materials[0].diffuse, vertex.texture_coordinate)"));
+}
+
+TEST(ShaderCompiler, StructuredReturnInsideNestedControlFlow) {
+  Compiler compiler;
+  static constexpr std::string_view src = R"axsl(
+@version 450;
+
+interface VertexOutput {
+    @location(0) vec3 texture_coordinate;
+}
+
+interface FragmentResources {
+    @uniform samplerCube skybox;
+}
+
+interface FragmentOutput {
+    @location(0) vec4 color;
+}
+
+@fragment
+fn main(VertexOutput vertex, FragmentResources fragment) -> FragmentOutput {
+    vec4 sample = texture(fragment.skybox, vertex.texture_coordinate);
+    float factor = 0.25;
+
+    if (sample.r > 0.5) {
+        for (int i = 0; i < 2; ++i) {
+            factor += sample.g > 0.25 ? 0.5 : 0.25;
+        }
+    }
+
+    return FragmentOutput(vec4(sample.rgb * factor, sample.a));
+}
+)axsl";
+  auto result = compiler.compile(src);
+  ASSERT_TRUE(result.ok()) << errors_str(result);
+
+  const auto &frag = result.stages.at(StageKind::Fragment);
+  EXPECT_TRUE(contains(frag, "texture(_skybox, vertex.texture_coordinate)"));
+  EXPECT_TRUE(contains(frag, "if (sample.r > 0.5)"));
+  EXPECT_TRUE(contains(frag, "for (int i = 0; i < 2; ++i)"));
+  EXPECT_TRUE(contains(frag, "sample.g > 0.25 ? 0.5 : 0.25"));
+  EXPECT_TRUE(
+      contains(frag, "_out_color = vec4(sample.rgb * factor, sample.a);"));
+}
+
+TEST(ShaderCompiler, GlobalUniformSharedAcrossStages) {
+  Compiler compiler;
+  static constexpr std::string_view src = R"axsl(
+@version 450;
+
+uniform mat4 view_projection;
+
+interface FragmentOutput {
+    @location(0) vec4 color;
+}
+
+@vertex
+fn main() -> void {
+    gl_Position = view_projection * vec4(0.0, 0.0, 0.0, 1.0);
+}
+
+@fragment
+fn main() -> FragmentOutput {
+    mat4 vp = view_projection;
+    return FragmentOutput(vec4(vp[0][0], 0.0, 0.0, 1.0));
+}
+)axsl";
+  auto result = compiler.compile(src);
+  ASSERT_TRUE(result.ok()) << errors_str(result);
+
+  const auto &vert = result.stages.at(StageKind::Vertex);
+  const auto &frag = result.stages.at(StageKind::Fragment);
+
+  EXPECT_TRUE(contains(vert, "uniform mat4 view_projection"));
+  EXPECT_TRUE(contains(frag, "uniform mat4 view_projection"));
+}
+
+TEST(ShaderCompiler, GlobalUniformUsageFiltering) {
+  Compiler compiler;
+  static constexpr std::string_view src = R"axsl(
+@version 450;
+
+uniform mat4 model_matrix;
+
+interface FragmentOutput {
+    @location(0) vec4 color;
+}
+
+@vertex
+fn main() -> void {
+    gl_Position = model_matrix * vec4(0.0, 0.0, 0.0, 1.0);
+}
+
+@fragment
+fn main() -> FragmentOutput {
+    return FragmentOutput(vec4(1.0, 0.0, 0.0, 1.0));
+}
+)axsl";
+  auto result = compiler.compile(src);
+  ASSERT_TRUE(result.ok()) << errors_str(result);
+
+  const auto &vert = result.stages.at(StageKind::Vertex);
+  EXPECT_TRUE(contains(vert, "uniform mat4 model_matrix"));
+
+  const auto &frag = result.stages.at(StageKind::Fragment);
+  EXPECT_FALSE(contains(frag, "model_matrix"));
+}
+
+TEST(ShaderCompiler, UniformShadowing) {
+  Compiler compiler;
+  static constexpr std::string_view src = R"axsl(
+@version 450;
+
+uniform float global_value = 1.0;
+
+interface FragmentResources {
+    @uniform float global_value;
+}
+
+interface FragmentOutput {
+    @location(0) vec4 color;
+}
+
+@vertex
+fn main() -> void {
+    float x = global_value;
+    gl_Position = vec4(x, 0.0, 0.0, 1.0);
+}
+
+@fragment
+fn main(FragmentResources resources) -> FragmentOutput {
+    float x = resources.global_value;
+    return FragmentOutput(vec4(x, 0.0, 0.0, 1.0));
+}
+)axsl";
+  auto result = compiler.compile(src);
+  ASSERT_TRUE(result.ok()) << errors_str(result);
+
+  EXPECT_TRUE(result.errors.empty());
+
+  const auto &vert = result.stages.at(StageKind::Vertex);
+  EXPECT_TRUE(contains(vert, "uniform float global_value = 1"));
+
+  const auto &frag = result.stages.at(StageKind::Fragment);
+  EXPECT_FALSE(contains(frag, "uniform float global_value = 1"));
+  EXPECT_TRUE(contains(frag, "uniform float _global_value"));
+}
+
+TEST(ShaderCompiler, GlobalUniformBufferSharing) {
+  Compiler compiler;
+  static constexpr std::string_view src = R"axsl(
+@version 450;
+
+@binding(0) uniform CameraData {
+    mat4 view;
+    mat4 projection;
+} camera;
+
+interface FragmentOutput {
+    @location(0) vec4 color;
+}
+
+@vertex
+fn main() -> void {
+    gl_Position = camera.projection * camera.view * vec4(0.0, 0.0, 0.0, 1.0);
+}
+
+@fragment
+fn main() -> FragmentOutput {
+    mat4 view = camera.view;
+    return FragmentOutput(vec4(view[0][0], 0.0, 0.0, 1.0));
+}
+)axsl";
+  auto result = compiler.compile(src);
+  ASSERT_TRUE(result.ok()) << errors_str(result);
+
+  const auto &vert = result.stages.at(StageKind::Vertex);
+  const auto &frag = result.stages.at(StageKind::Fragment);
+  EXPECT_TRUE(contains(vert, "uniform CameraData {"));
+  EXPECT_TRUE(contains(vert, "} camera;"));
+  EXPECT_TRUE(contains(frag, "uniform CameraData {"));
+  EXPECT_TRUE(contains(frag, "} camera;"));
+}
+
+TEST(ShaderCompiler, ShadowingUniformBuffer) {
+  Compiler compiler;
+  static constexpr std::string_view src = R"axsl(
+@version 450;
+
+uniform LightData {
+    vec3 position;
+} light;
+
+interface FragmentLight {
+    @uniform vec3 position;
+    @uniform vec3 color;
+}
+
+interface FragmentOutput {
+    @location(0) vec4 color;
+}
+
+@vertex
+fn main() -> void {
+    vec3 pos = light.position;
+    gl_Position = vec4(pos, 1.0);
+}
+
+@fragment
+fn main(FragmentLight light) -> FragmentOutput {
+    return FragmentOutput(vec4(light.color, 1.0));
+}
+)axsl";
+  auto result = compiler.compile(src);
+  ASSERT_TRUE(result.ok()) << errors_str(result);
+
+  EXPECT_TRUE(result.errors.empty());
+
+  const auto &vert = result.stages.at(StageKind::Vertex);
+  EXPECT_TRUE(contains(vert, "uniform LightData {"));
+  EXPECT_TRUE(contains(vert, "vec3 position;"));
+  EXPECT_FALSE(contains(vert, "vec3 color;"));
+
+  const auto &frag = result.stages.at(StageKind::Fragment);
+  EXPECT_FALSE(contains(frag, "uniform LightData {"));
+  EXPECT_FALSE(contains(frag, "uniform vec3 _position;"));
+  EXPECT_TRUE(contains(frag, "uniform vec3 _color;"));
+}
+
+TEST(ShaderCompiler, UnusedGlobalUniformNotEmitted) {
+  Compiler compiler;
+  static constexpr std::string_view src = R"axsl(
+@version 450;
+
+uniform float unused_global;
+
+@vertex
+fn main() -> void {
+    gl_Position = vec4(0.0, 0.0, 0.0, 1.0);
+}
+)axsl";
+  auto result = compiler.compile(src);
+  ASSERT_TRUE(result.ok()) << errors_str(result);
+
+  const auto &vert = result.stages.at(StageKind::Vertex);
+  EXPECT_FALSE(contains(vert, "unused_global"));
+}
+
+TEST(ShaderCompiler, GlobalUniformWithStageSpecific) {
+  Compiler compiler;
+  static constexpr std::string_view src = R"axsl(
+@version 450;
+
+uniform vec3 global_light_pos;
+uniform mat4 model;
+
+interface FragmentResources {
+    @uniform vec3 frag_light_color;
+}
+
+interface FragmentOutput {
+    @location(0) vec4 color;
+}
+
+@vertex
+fn main() -> void {
+    vec3 light = global_light_pos;
+    gl_Position = model * vec4(light, 1.0);
+}
+
+@fragment
+fn main(FragmentResources resources) -> FragmentOutput {
+    vec3 light = global_light_pos;
+    return FragmentOutput(vec4(resources.frag_light_color * light, 1.0));
+}
+)axsl";
+  auto result = compiler.compile(src);
+  ASSERT_TRUE(result.ok()) << errors_str(result);
+
+  const auto &vert = result.stages.at(StageKind::Vertex);
+  const auto &frag = result.stages.at(StageKind::Fragment);
+
+  EXPECT_TRUE(contains(vert, "uniform vec3 global_light_pos"));
+  EXPECT_TRUE(contains(frag, "uniform vec3 global_light_pos"));
+
+  EXPECT_TRUE(contains(vert, "uniform mat4 model"));
+  EXPECT_FALSE(contains(frag, "uniform mat4 model"));
+
+  EXPECT_FALSE(contains(vert, "_frag_light_color"));
+  EXPECT_TRUE(contains(frag, "uniform vec3 _frag_light_color"));
+}
+
+static std::string first_error(const CompileResult &r) {
+  return r.errors.empty() ? "" : r.errors[0];
+}
+
+static constexpr std::string_view k_unclosed_stage =
+    "@version 450;\n"
+    "@vertex fn main() -> void {";
+
+TEST(ShaderDiagnostics, ErrorHasFilenameWhenProvided) {
+  Compiler compiler;
+  auto result = compiler.compile(k_unclosed_stage, "", "myshader.axsl");
+  ASSERT_FALSE(result.ok());
+  const auto err = first_error(result);
+  EXPECT_NE(err.find("myshader.axsl:"), std::string::npos)
+      << "Expected filename prefix in error:\n"
+      << err;
+}
+
+TEST(ShaderDiagnostics, ErrorHasFileLineColFormat) {
+  Compiler compiler;
+  auto result = compiler.compile(k_unclosed_stage, "", "s.axsl");
+  ASSERT_FALSE(result.ok());
+  const auto err = first_error(result);
+  auto file_pos = err.find("s.axsl:");
+  ASSERT_NE(file_pos, std::string::npos) << err;
+  auto after_file = file_pos + 7;
+  EXPECT_TRUE(std::isdigit(static_cast<unsigned char>(err[after_file])))
+      << "Expected line digit after filename:\n"
+      << err;
+  auto colon2 = err.find(':', after_file);
+  ASSERT_NE(colon2, std::string::npos) << err;
+  EXPECT_TRUE(std::isdigit(static_cast<unsigned char>(err[colon2 + 1])))
+      << "Expected col digit after second colon:\n"
+      << err;
+  auto colon3 = err.find(':', colon2 + 1);
+  ASSERT_NE(colon3, std::string::npos) << err;
+  EXPECT_EQ(err[colon3 + 1], ' ') << "Expected space after file:line:col:\n"
+                                  << err;
+}
+
+TEST(ShaderDiagnostics, ErrorHasNoFilePrefixWhenOmitted) {
+  Compiler compiler;
+  auto result = compiler.compile(k_unclosed_stage);
+  ASSERT_FALSE(result.ok());
+  const auto err = first_error(result);
+  EXPECT_TRUE(std::isdigit(static_cast<unsigned char>(err[0])))
+      << "Expected line digit at start of error:\n"
+      << err;
+}
+
+TEST(ShaderDiagnostics, ErrorContainsSourceContextSeparator) {
+  Compiler compiler;
+  auto result = compiler.compile(k_unclosed_stage, "", "ctx.axsl");
+  ASSERT_FALSE(result.ok());
+  const auto err = errors_str(result);
+  EXPECT_NE(err.find(" | "), std::string::npos)
+      << "Expected source context (\" | \") in error output:\n"
+      << err;
+}
+
+TEST(ShaderDiagnostics, ErrorContainsCaretMarker) {
+  Compiler compiler;
+  auto result = compiler.compile(k_unclosed_stage, "", "caret.axsl");
+  ASSERT_FALSE(result.ok());
+  const auto err = errors_str(result);
+  EXPECT_NE(err.find('^'), std::string::npos)
+      << "Expected caret marker in error output:\n"
+      << err;
+}
+
+TEST(ShaderDiagnostics, FormatSourceContextBasic) {
+  std::string_view src = "aaa\nbbb\nccc\n";
+  std::string ctx = format_source_context(src, 2, 2, 1);
+  EXPECT_NE(ctx.find("1 | aaa"), std::string::npos) << ctx;
+  EXPECT_NE(ctx.find("2 | bbb"), std::string::npos) << ctx;
+  EXPECT_NE(ctx.find("3 | ccc"), std::string::npos) << ctx;
+  EXPECT_NE(ctx.find(" | "), std::string::npos) << ctx;
+  EXPECT_NE(ctx.find('^'), std::string::npos) << ctx;
+}
+
+TEST(ShaderDiagnostics, FormatSourceContextCaretColumn) {
+  std::string_view src = "hello\nworld\n";
+  std::string ctx = format_source_context(src, 1, 1, 0);
+  EXPECT_NE(ctx.find("1 | hello"), std::string::npos) << ctx;
+  EXPECT_NE(ctx.find("  | ^"), std::string::npos) << ctx;
+}
+
+TEST(ShaderDiagnostics, FormatSourceContextOutOfRange) {
+  std::string_view src = "foo\n";
+  EXPECT_EQ(format_source_context(src, 0, 1), "");
+  EXPECT_EQ(format_source_context(src, 99, 1), "");
+}
+
+TEST(ShaderDiagnostics, ErrorMessageContainsErrorText) {
+  Compiler compiler;
+  auto result = compiler.compile(k_unclosed_stage, "", "msg.axsl");
+  ASSERT_FALSE(result.ok());
+  const auto err = errors_str(result);
+  EXPECT_NE(err.find("expected"), std::string::npos)
+      << "Expected 'expected' keyword in error message:\n"
+      << err;
+}
+
+TEST(ShaderDiagnostics, GlobalScopeUnexpectedTokenHasContext) {
+  static constexpr std::string_view src = "@version 450;\n"
+                                          "if (true) {}\n";
+  Compiler compiler;
+  auto result = compiler.compile(src, "", "global.axsl");
+  ASSERT_FALSE(result.ok());
+  const auto err = first_error(result);
+  EXPECT_NE(err.find("global.axsl:2:"), std::string::npos)
+      << "Expected global-scope error on line 2:\n"
+      << err;
+  EXPECT_NE(err.find("unexpected token in global scope"), std::string::npos)
+      << err;
+  EXPECT_NE(err.find("expected a global declaration"), std::string::npos)
+      << err;
+  EXPECT_NE(err.find("2 | if (true) {}"), std::string::npos) << err;
+}
+
+TEST(ShaderDiagnostics, MissingSemicolonAfterOutBlockPointsToSameLine) {
+  static constexpr std::string_view src = "@version 450;\n"
+                                          "@binding(0) uniform CameraData {\n"
+                                          "    mat4 view;\n"
+                                          "} camera\n"
+                                          "@vertex fn main() -> void {\n"
+                                          "    gl_Position = vec4(0.0);\n"
+                                          "}\n";
+  Compiler compiler;
+  auto result = compiler.compile(src, "", "t.axsl");
+  ASSERT_FALSE(result.ok());
+  const auto err = first_error(result);
+  EXPECT_NE(err.find("t.axsl:4:"), std::string::npos)
+      << "Expected error on line 4:\n"
+      << err;
+  EXPECT_EQ(err.find("t.axsl:5:"), std::string::npos)
+      << "Error must not point to line 5 (next token):\n"
+      << err;
+}
+
+TEST(ShaderDiagnostics, MissingSemicolonAfterUniformPointsToSameLine) {
+  static constexpr std::string_view src = "@version 450;\n"
+                                          "uniform float x\n"
+                                          "@vertex fn main() -> void {\n"
+                                          "    gl_Position = vec4(0.0);\n"
+                                          "}\n";
+  Compiler compiler;
+  auto result = compiler.compile(src, "", "t.axsl");
+  ASSERT_FALSE(result.ok());
+  const auto err = first_error(result);
+  EXPECT_NE(err.find("t.axsl:2:"), std::string::npos)
+      << "Expected error on line 2:\n"
+      << err;
+  EXPECT_EQ(err.find("t.axsl:3:"), std::string::npos)
+      << "Error must not point to line 3 (next token):\n"
+      << err;
+}
+
+TEST(ShaderDiagnostics, MissingFieldNamePointsToSameLine) {
+  static constexpr std::string_view src = "@version 450;\n"
+                                          "struct Foo {\n"
+                                          "    vec3 ;\n"
+                                          "    float y;\n"
+                                          "};\n";
+  Compiler compiler;
+  auto result = compiler.compile(src, "", "t.axsl");
+  ASSERT_FALSE(result.ok());
+  const auto err = first_error(result);
+  EXPECT_NE(err.find("t.axsl:3:"), std::string::npos)
+      << "Expected error on line 3:\n"
+      << err;
+  EXPECT_EQ(err.find("t.axsl:4:"), std::string::npos)
+      << "Error must not point to line 4 (next token):\n"
+      << err;
+}
+
+} // namespace astralix

--- a/src/modules/renderer/shader-lang/diagnostics.hpp
+++ b/src/modules/renderer/shader-lang/diagnostics.hpp
@@ -1,0 +1,264 @@
+#pragma once
+
+#include "shader-lang/ast.hpp"
+#include <cstdio>
+#include <cstdint>
+#include <initializer_list>
+#include <sstream>
+#include <string>
+#include <string_view>
+#include <vector>
+
+namespace astralix {
+#define ERROR_AT_LOC(msg, name, location)                                      \
+  (std::string(msg) + ": '" + (name) + "' at " +                               \
+   std::to_string((location).line) + ":" + std::to_string((location).col))
+
+#define PUSH_ERROR(result, msg, name, location)                                \
+  (result).errors.push_back(ERROR_AT_LOC(msg, name, location))
+
+#define PUSH_UNDEFINED_IDENTIFIER(result, name, location)                      \
+  PUSH_ERROR(result, "undefined identifier", name, location)
+
+#define PUSH_UNRESOLVED_SYMBOL(result, name, location)                         \
+  PUSH_ERROR(result, "unresolved symbol", name, location)
+
+#define PUSH_CANNOT_OPEN_INCLUDE(result, path)                                 \
+  (result).errors.push_back("cannot open include: '" + std::string(path) + "'")
+
+#define PUSH_PREFIXED_INCLUDE_ERROR(result, include_path, error_msg)           \
+  (result).errors.push_back("[" + std::string(include_path) + "] " +           \
+                            std::string(error_msg))
+
+#define PUSH_LOCATED_ERROR(errors, location, message, source)                  \
+  ::astralix::push_located_error((errors), (location), (message), (source))
+
+#define PUSH_INVALID_ATTRIBUTE(errors, attribute, target, source, ...)         \
+  PUSH_LOCATED_ERROR(                                                          \
+      (errors), (attribute).location,                                          \
+      ::astralix::format_invalid_attribute_message(                            \
+          ::astralix::attribute_kind_name((attribute).kind), (target),         \
+          std::initializer_list<::astralix::AttributeKind>{__VA_ARGS__}),      \
+      (source))
+
+#define PUSH_INVALID_ANNOTATION(errors, annotation, target, source, ...)       \
+  PUSH_LOCATED_ERROR(                                                          \
+      (errors), (annotation).location,                                         \
+      ::astralix::format_invalid_annotation_message(                           \
+          ::astralix::annotation_kind_name((annotation).kind), (target),       \
+          std::initializer_list<::astralix::AnnotationKind>{__VA_ARGS__}),     \
+      (source))
+
+#define PUSH_ATTRIBUTE_EXCLUSIVE_CONFLICT(errors, attribute, target, source,   \
+                                          conflicting_kind)                    \
+  PUSH_LOCATED_ERROR(                                                          \
+      (errors), (attribute).location,                                          \
+      ::astralix::format_attribute_exclusive_conflict_message(                 \
+          ::astralix::attribute_kind_name((attribute).kind), (target),         \
+          ::astralix::attribute_kind_name((conflicting_kind))),                \
+      (source))
+
+#define PUSH_ANNOTATION_EXCLUSIVE_CONFLICT(errors, annotation, target, source, \
+                                           conflicting_kind)                   \
+  PUSH_LOCATED_ERROR(                                                          \
+      (errors), (annotation).location,                                         \
+      ::astralix::format_annotation_exclusive_conflict_message(                \
+          ::astralix::annotation_kind_name((annotation).kind), (target),       \
+          ::astralix::annotation_kind_name((conflicting_kind))),               \
+      (source))
+
+inline std::string format_location_prefix(const SourceLocation &location) {
+  return location.file.empty() ? (std::to_string(location.line) + ":" +
+                                  std::to_string(location.col) + ": ")
+                               : (std::string(location.file) + ":" +
+                                  std::to_string(location.line) + ":" +
+                                  std::to_string(location.col) + ": ");
+}
+
+inline std::string format_source_context(std::string_view source, uint32_t line,
+                                         uint32_t col,
+                                         uint32_t context_lines = 2) {
+  std::vector<std::string_view> lines;
+  size_t start = 0;
+  for (size_t i = 0; i <= source.size(); ++i) {
+    if (i == source.size() || source[i] == '\n') {
+      lines.push_back(source.substr(start, i - start));
+      start = i + 1;
+    }
+  }
+
+  if (line == 0 || line > static_cast<uint32_t>(lines.size()))
+    return {};
+
+  uint32_t first = (line > context_lines + 1) ? (line - context_lines) : 1;
+  uint32_t last =
+      std::min(static_cast<uint32_t>(lines.size()), line + context_lines);
+
+  int width = static_cast<int>(std::to_string(last).size());
+
+  std::ostringstream out;
+
+  for (uint32_t l = first; l <= last; ++l) {
+    std::string line_number = std::to_string(l);
+
+    out << std::string(width - static_cast<int>(line_number.size()), ' ')
+        << line_number << " | " << lines[l - 1] << '\n';
+    if (l == line) {
+      out << std::string(width, ' ') << " | ";
+      uint32_t pad = (col > 0) ? (col - 1) : 0;
+      out << std::string(pad, ' ') << "^\n";
+    }
+  }
+  return out.str();
+}
+
+inline std::string format_located_error(std::string message,
+                                        const SourceLocation &location,
+                                        std::string_view source = {}) {
+  std::string error = format_location_prefix(location) + std::move(message);
+
+  if (!source.empty()) {
+    std::string context =
+        format_source_context(source, location.line, location.col);
+    if (!context.empty()) {
+      error += '\n' + context;
+    }
+  }
+
+  return error;
+}
+
+inline std::string format_invalid_attribute_message(
+    std::string_view attribute_name, std::string_view target,
+    std::string_view allowed_desc) {
+  return "invalid attribute '" + std::string(attribute_name) + "' on " +
+         std::string(target) + "; " + std::string(allowed_desc);
+}
+
+inline std::string
+format_allowed_attributes(std::initializer_list<AttributeKind> allowed) {
+  if (allowed.size() == 0) {
+    return "no attributes are allowed";
+  }
+
+  std::string message = "only ";
+  size_t index = 0;
+
+  for (AttributeKind kind : allowed) {
+    if (index > 0) {
+      if (allowed.size() == 2) {
+        message += " and ";
+      } else if (index == allowed.size() - 1) {
+        message += ", and ";
+      } else {
+        message += ", ";
+      }
+    }
+
+    message += "'";
+    message += attribute_kind_name(kind);
+    message += "'";
+    ++index;
+  }
+
+  message += allowed.size() == 1 ? " is allowed" : " are allowed";
+  return message;
+}
+
+inline std::string format_invalid_attribute_message(
+    std::string_view attribute_name, std::string_view target,
+    std::initializer_list<AttributeKind> allowed) {
+  return format_invalid_attribute_message(attribute_name, target,
+                                          format_allowed_attributes(allowed));
+}
+
+inline std::string format_attribute_exclusive_conflict_message(
+    std::string_view attribute_name, std::string_view target,
+    std::string_view conflicting_name) {
+  return "attribute '" + std::string(attribute_name) + "' conflicts with '" +
+         std::string(conflicting_name) + "' on " + std::string(target);
+}
+
+inline std::string
+format_allowed_annotations(std::initializer_list<AnnotationKind> allowed) {
+  if (allowed.size() == 0) {
+    return "no annotations are allowed";
+  }
+
+  std::string message = "only ";
+  size_t index = 0;
+
+  for (AnnotationKind kind : allowed) {
+    if (index > 0) {
+      if (allowed.size() == 2) {
+        message += " and ";
+      } else if (index == allowed.size() - 1) {
+        message += ", and ";
+      } else {
+        message += ", ";
+      }
+    }
+
+    message += "'";
+    message += annotation_kind_name(kind);
+    message += "'";
+    ++index;
+  }
+
+  message += allowed.size() == 1 ? " is allowed" : " are allowed";
+  return message;
+}
+
+inline std::string format_invalid_annotation_message(
+    std::string_view annotation_name, std::string_view target,
+    std::string_view allowed_desc) {
+  return "invalid annotation '" + std::string(annotation_name) + "' on " +
+         std::string(target) + "; " + std::string(allowed_desc);
+}
+
+inline std::string format_invalid_annotation_message(
+    std::string_view annotation_name, std::string_view target,
+    std::initializer_list<AnnotationKind> allowed) {
+  return format_invalid_annotation_message(annotation_name, target,
+                                           format_allowed_annotations(allowed));
+}
+
+inline std::string format_missing_required_annotation_message(
+    std::string_view annotation_name, std::string_view target) {
+  return "missing required annotation '" + std::string(annotation_name) +
+         "' on " + std::string(target);
+}
+
+inline std::string format_annotation_exclusive_conflict_message(
+    std::string_view annotation_name, std::string_view target,
+    std::string_view conflicting_name) {
+  return "annotation '" + std::string(annotation_name) + "' conflicts with '" +
+         std::string(conflicting_name) + "' on " + std::string(target);
+}
+
+inline void push_located_error(std::vector<std::string> &errors,
+                               const SourceLocation &location,
+                               std::string message,
+                               std::string_view source = {}) {
+  errors.push_back(format_located_error(std::move(message), location, source));
+}
+
+inline void report_parser_stuck(std::string_view parser_name,
+                                const Token &token) {
+  std::fprintf(stderr, "[axslc] %.*s: stuck at token '%s' (%d) line %u\n",
+               static_cast<int>(parser_name.size()), parser_name.data(),
+               token.lexeme.c_str(), static_cast<int>(token.kind),
+               token.location.line);
+}
+
+inline void report_parser_stuck(std::string_view parser_name,
+                                std::string_view scope_name,
+                                const Token &token) {
+  std::fprintf(stderr, "[axslc] %.*s(%.*s): stuck at '%s' (%d) line %u\n",
+               static_cast<int>(parser_name.size()), parser_name.data(),
+               static_cast<int>(scope_name.size()), scope_name.data(),
+               token.lexeme.c_str(), static_cast<int>(token.kind),
+               token.location.line);
+}
+
+} // namespace astralix

--- a/src/modules/renderer/shader-lang/emitters/opengl-glsl-emitter.cpp
+++ b/src/modules/renderer/shader-lang/emitters/opengl-glsl-emitter.cpp
@@ -1,0 +1,1584 @@
+#include "shader-lang/emitters/opengl-glsl-emitter.hpp"
+#include <cstdio>
+
+namespace astralix {
+
+namespace {
+
+template <class... Ts> struct Overloaded : Ts... {
+  using Ts::operator()...;
+};
+
+template <class... Ts> Overloaded(Ts...) -> Overloaded<Ts...>;
+
+bool should_emit_interface(bool is_in, StageKind stage) {
+  return (is_in && stage == StageKind::Fragment) ||
+         (!is_in && stage == StageKind::Vertex);
+}
+
+bool emits_as_storage_block(const InlineInterfaceDecl &interface_decl) {
+  return !interface_decl.annotations.empty();
+}
+
+std::optional<std::string>
+find_output_local_name(const std::vector<ASTNode> &nodes, NodeID id,
+                       std::string_view interface_name) {
+  if (const auto *var_decl = std::get_if<VarDecl>(&nodes[id].data)) {
+    if (var_decl->type.kind == TokenKind::Identifier &&
+        var_decl->type.name == interface_name) {
+      return var_decl->name;
+    }
+  }
+
+  std::optional<std::string> output_local_name;
+  visit_child_ids(nodes[id], [&](NodeID child_id) {
+    if (!output_local_name) {
+      output_local_name = find_output_local_name(nodes, child_id, interface_name);
+    }
+  });
+  return output_local_name;
+}
+
+void collect_resource_field_usage(
+    const std::vector<ASTNode> &nodes, NodeID id,
+    const std::unordered_set<std::string> &resource_param_names,
+    std::unordered_set<std::string> &used_resource_fields) {
+  if (const auto *field_expr = std::get_if<FieldExpr>(&nodes[id].data)) {
+    if (const auto *identifier_expr =
+            std::get_if<IdentifierExpr>(&nodes[field_expr->object].data)) {
+      if (resource_param_names.count(identifier_expr->name) > 0) {
+        used_resource_fields.insert(identifier_expr->name + "." +
+                                    field_expr->field);
+      }
+    }
+  }
+
+  visit_child_ids(nodes[id], [&](NodeID child_id) {
+    collect_resource_field_usage(nodes, child_id, resource_param_names,
+                                 used_resource_fields);
+  });
+}
+
+std::unordered_map<std::string, NodeID>
+collect_global_function_ids(const Program &program,
+                            const std::vector<ASTNode> &nodes) {
+  std::unordered_map<std::string, NodeID> function_ids;
+
+  for (NodeID global_id : program.globals) {
+    const auto *func_decl = std::get_if<FuncDecl>(&nodes[global_id].data);
+    if (!func_decl) {
+      continue;
+    }
+
+    function_ids.emplace(func_decl->name, global_id);
+  }
+
+  return function_ids;
+}
+
+void collect_reachable_function_calls(
+    const std::vector<ASTNode> &nodes, NodeID id,
+    const std::unordered_map<std::string, NodeID> &function_ids,
+    std::unordered_set<NodeID> &reachable_function_ids) {
+  if (const auto *call_expr = std::get_if<CallExpr>(&nodes[id].data)) {
+    const ASTNode &callee_node = nodes[call_expr->callee];
+    const std::string *callee_name = nullptr;
+
+    if (const auto *identifier_expr =
+            std::get_if<IdentifierExpr>(&callee_node.data)) {
+      callee_name = &identifier_expr->name;
+    } else if (const auto *unresolved_ref =
+                   std::get_if<UnresolvedRef>(&callee_node.data)) {
+      callee_name = &unresolved_ref->name;
+    }
+
+    if (callee_name) {
+      auto function_it = function_ids.find(*callee_name);
+      if (function_it != function_ids.end() &&
+          reachable_function_ids.insert(function_it->second).second) {
+        const auto &func_decl =
+            std::get<FuncDecl>(nodes[function_it->second].data);
+        collect_reachable_function_calls(nodes, func_decl.body, function_ids,
+                                         reachable_function_ids);
+      }
+    }
+  }
+
+  visit_child_ids(nodes[id], [&](NodeID child_id) {
+    collect_reachable_function_calls(nodes, child_id, function_ids,
+                                     reachable_function_ids);
+  });
+}
+
+std::unordered_set<NodeID>
+collect_stage_function_ids(const Program &program,
+                           const std::vector<ASTNode> &nodes,
+                           const FuncDecl *entry) {
+  std::unordered_set<NodeID> reachable_function_ids;
+  auto function_ids = collect_global_function_ids(program, nodes);
+
+  if (entry) {
+    collect_reachable_function_calls(nodes, entry->body, function_ids,
+                                     reachable_function_ids);
+  }
+
+  for (NodeID global_id : program.globals) {
+    if (std::holds_alternative<FuncDecl>(nodes[global_id].data)) {
+      continue;
+    }
+
+    collect_reachable_function_calls(nodes, global_id, function_ids,
+                                     reachable_function_ids);
+  }
+
+  return reachable_function_ids;
+}
+
+std::unordered_map<std::string, NodeID>
+collect_global_struct_ids(const Program &program,
+                          const std::vector<ASTNode> &nodes) {
+  std::unordered_map<std::string, NodeID> struct_ids;
+
+  for (NodeID global_id : program.globals) {
+    const auto *struct_decl = std::get_if<StructDecl>(&nodes[global_id].data);
+    if (!struct_decl) {
+      continue;
+    }
+
+    struct_ids.emplace(struct_decl->name, global_id);
+  }
+
+  return struct_ids;
+}
+
+void collect_struct_dependencies_from_node(
+    NodeID id, const std::unordered_map<std::string, NodeID> &struct_ids,
+    const std::vector<ASTNode> &nodes, std::unordered_set<NodeID> &struct_usage);
+
+void collect_struct_dependencies_from_type(
+    const TypeRef &type, const std::unordered_map<std::string, NodeID> &struct_ids,
+    const std::vector<ASTNode> &nodes, std::unordered_set<NodeID> &struct_usage) {
+  if (type.kind != TokenKind::Identifier) {
+    return;
+  }
+
+  auto struct_it = struct_ids.find(type.name);
+  if (struct_it == struct_ids.end() ||
+      !struct_usage.insert(struct_it->second).second) {
+    return;
+  }
+
+  const auto &struct_decl = std::get<StructDecl>(nodes[struct_it->second].data);
+  for (NodeID field_id : struct_decl.fields) {
+    const auto &field_decl = std::get<FieldDecl>(nodes[field_id].data);
+    collect_struct_dependencies_from_type(field_decl.type, struct_ids, nodes,
+                                          struct_usage);
+
+    if (field_decl.init) {
+      collect_struct_dependencies_from_node(*field_decl.init, struct_ids, nodes,
+                                            struct_usage);
+    }
+  }
+}
+
+void collect_struct_dependencies_from_node(
+    NodeID id, const std::unordered_map<std::string, NodeID> &struct_ids,
+    const std::vector<ASTNode> &nodes, std::unordered_set<NodeID> &struct_usage) {
+  const ASTNode &current_node = nodes[id];
+
+  if (const auto *var_decl = std::get_if<VarDecl>(&current_node.data)) {
+    collect_struct_dependencies_from_type(var_decl->type, struct_ids, nodes,
+                                          struct_usage);
+  } else if (const auto *param_decl =
+                 std::get_if<ParamDecl>(&current_node.data)) {
+    collect_struct_dependencies_from_type(param_decl->type, struct_ids, nodes,
+                                          struct_usage);
+  } else if (const auto *func_decl = std::get_if<FuncDecl>(&current_node.data)) {
+    collect_struct_dependencies_from_type(func_decl->ret, struct_ids, nodes,
+                                          struct_usage);
+  } else if (const auto *field_decl =
+                 std::get_if<FieldDecl>(&current_node.data)) {
+    collect_struct_dependencies_from_type(field_decl->type, struct_ids, nodes,
+                                          struct_usage);
+  } else if (const auto *uniform_decl =
+                 std::get_if<UniformDecl>(&current_node.data)) {
+    collect_struct_dependencies_from_type(uniform_decl->type, struct_ids, nodes,
+                                          struct_usage);
+  } else if (const auto *construct_expr =
+                 std::get_if<ConstructExpr>(&current_node.data)) {
+    collect_struct_dependencies_from_type(construct_expr->type, struct_ids,
+                                          nodes, struct_usage);
+  } else if (const auto *call_expr = std::get_if<CallExpr>(&current_node.data)) {
+    const ASTNode &callee_node = nodes[call_expr->callee];
+
+    if (const auto *identifier_expr =
+            std::get_if<IdentifierExpr>(&callee_node.data)) {
+      collect_struct_dependencies_from_type(
+          TypeRef{TokenKind::Identifier, identifier_expr->name}, struct_ids,
+          nodes, struct_usage);
+    } else if (const auto *unresolved_ref =
+                   std::get_if<UnresolvedRef>(&callee_node.data)) {
+      collect_struct_dependencies_from_type(
+          TypeRef{TokenKind::Identifier, unresolved_ref->name}, struct_ids,
+          nodes, struct_usage);
+    }
+  }
+
+  visit_child_ids(current_node, [&](NodeID child_id) {
+    collect_struct_dependencies_from_node(child_id, struct_ids, nodes,
+                                          struct_usage);
+  });
+}
+
+} // namespace
+
+OpenGLGLSLEmitter::OpenGLGLSLEmitter(const std::vector<ASTNode> &nodes)
+    : m_nodes(nodes) {}
+
+void OpenGLGLSLEmitter::write(std::string_view text) { m_out += text; }
+
+void OpenGLGLSLEmitter::writeln(std::string_view text) {
+  m_out += m_indent;
+  m_out += text;
+  m_out += '\n';
+}
+
+void OpenGLGLSLEmitter::push_indent() { m_indent += "  "; }
+
+void OpenGLGLSLEmitter::pop_indent() {
+  if (m_indent.size() >= 2)
+    m_indent.resize(m_indent.size() - 2);
+}
+
+const ASTNode &OpenGLGLSLEmitter::node(NodeID id) const { return m_nodes[id]; }
+
+std::string
+OpenGLGLSLEmitter::emit(const Program &program, StageKind stage,
+                        const std::unordered_set<std::string> &used_uniforms) {
+  m_out.clear();
+  m_indent.clear();
+
+  writeln("#version 450 core");
+  writeln();
+
+  const FuncDecl *entry = find_stage_entry(program, stage);
+  EntryContext ctx{stage};
+  const EntryContext *ctx_ptr = nullptr;
+  if (entry) {
+    ctx = build_entry_context(program, stage, *entry);
+    ctx_ptr = &ctx;
+  }
+
+  emit_globals(program, stage, used_uniforms, entry, ctx_ptr);
+
+  const auto stage_resource_emitter = Overloaded{
+      [&](const UniformDecl &decl) {
+        emit_stage_resource_if_used(decl, stage, program, used_uniforms);
+      },
+      [&](const BufferDecl &decl) {
+        emit_stage_resource_if_used(decl, stage, program, used_uniforms);
+      },
+      [&](const auto &) {}};
+
+  for (NodeID gid : program.globals) {
+    std::visit(stage_resource_emitter, node(gid).data);
+  }
+
+  if (!entry) {
+    return m_out;
+  }
+
+  emit_entry_signature(ctx);
+  emit_entry_main(*entry, ctx);
+
+  return m_out;
+}
+
+void OpenGLGLSLEmitter::emit_globals(
+    const Program &prog, StageKind stage,
+    const std::unordered_set<std::string> &used_uniforms, const FuncDecl *entry,
+    const EntryContext *ctx) {
+  std::unordered_set<NodeID> stage_function_ids =
+      collect_stage_function_ids(prog, m_nodes, entry);
+  std::unordered_set<NodeID> stage_struct_ids;
+  auto struct_ids = collect_global_struct_ids(prog, m_nodes);
+
+  auto collect_interface_structs = [&](const InterfaceDecl *interface_decl,
+                                       const std::string *param_name) {
+    if (!interface_decl) {
+      return;
+    }
+
+    for (NodeID field_id : interface_decl->fields) {
+      if (ctx && param_name) {
+        const auto &field_decl = std::get<FieldDecl>(m_nodes[field_id].data);
+        std::string key = *param_name + "." + field_decl.name;
+        if (ctx->resource_aliases.count(key) == 0 &&
+            ctx->used_resource_fields.count(key) == 0) {
+          continue;
+        }
+      }
+
+      collect_struct_dependencies_from_node(field_id, struct_ids, m_nodes,
+                                            stage_struct_ids);
+    }
+  };
+
+  if (entry) {
+    collect_struct_dependencies_from_type(entry->ret, struct_ids, m_nodes,
+                                          stage_struct_ids);
+
+    for (NodeID param_id : entry->params) {
+      const auto &param_decl = std::get<ParamDecl>(node(param_id).data);
+      collect_struct_dependencies_from_type(param_decl.type, struct_ids, m_nodes,
+                                            stage_struct_ids);
+    }
+
+    collect_struct_dependencies_from_node(entry->body, struct_ids, m_nodes,
+                                          stage_struct_ids);
+  }
+
+  if (ctx) {
+    collect_interface_structs(ctx->output_interface, nullptr);
+
+    for (const auto &[param_name, interface_decl] : ctx->varying_inputs) {
+      (void)param_name;
+      collect_interface_structs(interface_decl, nullptr);
+    }
+
+    for (const auto &[param_name, interface_decl] : ctx->resource_inputs) {
+      collect_interface_structs(interface_decl, &param_name);
+    }
+  }
+
+  for (NodeID function_id : stage_function_ids) {
+    collect_struct_dependencies_from_node(function_id, struct_ids, m_nodes,
+                                          stage_struct_ids);
+  }
+
+  for (NodeID global_id : prog.globals) {
+    const ASTNode &global_node = node(global_id);
+
+    if (std::holds_alternative<VarDecl>(global_node.data)) {
+      collect_struct_dependencies_from_node(global_id, struct_ids, m_nodes,
+                                            stage_struct_ids);
+      continue;
+    }
+
+    if (const auto *interface_decl =
+            std::get_if<InlineInterfaceDecl>(&global_node.data)) {
+      if (emits_as_storage_block(*interface_decl) ||
+          should_emit_interface(interface_decl->is_in, stage)) {
+        collect_struct_dependencies_from_node(global_id, struct_ids, m_nodes,
+                                              stage_struct_ids);
+      }
+      continue;
+    }
+
+    if (const auto *interface_ref =
+            std::get_if<InterfaceRef>(&global_node.data)) {
+      if (!should_emit_interface(interface_ref->is_in, stage)) {
+        continue;
+      }
+
+      collect_interface_structs(find_interface(prog, interface_ref->block_name),
+                                nullptr);
+      continue;
+    }
+
+    if (const auto *uniform_decl = std::get_if<UniformDecl>(&global_node.data)) {
+      if (used_uniforms.count(uniform_decl->name) &&
+          !is_shadowed(uniform_decl->name, stage, prog)) {
+        collect_struct_dependencies_from_node(global_id, struct_ids, m_nodes,
+                                              stage_struct_ids);
+      }
+      continue;
+    }
+
+    if (const auto *buffer_decl = std::get_if<BufferDecl>(&global_node.data)) {
+      if (buffer_decl->instance_name &&
+          used_uniforms.count(*buffer_decl->instance_name) &&
+          !is_shadowed(*buffer_decl->instance_name, stage, prog)) {
+        collect_struct_dependencies_from_node(global_id, struct_ids, m_nodes,
+                                              stage_struct_ids);
+      }
+    }
+  }
+
+  const auto struct_emitter = Overloaded{
+      [&](const StructDecl &decl, NodeID global_id) {
+        if (stage_struct_ids.count(global_id) == 0) {
+          return;
+        }
+
+        emit_struct(decl);
+      },
+      [&](const auto &, NodeID) {}};
+
+  bool emitted_function_prototype = false;
+  const auto function_prototype_emitter = Overloaded{
+      [&](const FuncDecl &decl, NodeID global_id) {
+        if (stage_function_ids.count(global_id) == 0) {
+          return;
+        }
+
+        emit_function_prototype(decl);
+        emitted_function_prototype = true;
+      },
+      [&](const auto &, NodeID) {}};
+
+  const auto non_function_decl_emitter =
+      Overloaded{[&](const VarDecl &decl) { emit_global_var(decl); },
+                 [&](const InlineInterfaceDecl &decl) {
+                   emit_global_inline_interface(decl, stage);
+                 },
+                 [&](const InterfaceRef &decl) {
+                   emit_global_interface_ref(decl, prog, stage);
+                 },
+                 [&](const auto &) {}};
+
+  const auto function_definition_emitter = Overloaded{
+      [&](const FuncDecl &decl, NodeID global_id) {
+        if (stage_function_ids.count(global_id) == 0) {
+          return;
+        }
+
+        emit_function(decl);
+      },
+      [&](const auto &, NodeID) {}};
+
+  for (NodeID global_id : prog.globals) {
+    std::visit([&](const auto &decl) { struct_emitter(decl, global_id); },
+               node(global_id).data);
+  }
+
+  for (NodeID global_id : prog.globals) {
+    std::visit(
+        [&](const auto &decl) { function_prototype_emitter(decl, global_id); },
+        node(global_id).data);
+  }
+
+  if (emitted_function_prototype) {
+    writeln();
+  }
+
+  for (NodeID global_id : prog.globals) {
+    std::visit(non_function_decl_emitter, node(global_id).data);
+  }
+
+  for (NodeID global_id : prog.globals) {
+    std::visit(
+        [&](const auto &decl) { function_definition_emitter(decl, global_id); },
+        node(global_id).data);
+  }
+}
+
+void OpenGLGLSLEmitter::emit_global_var(const VarDecl &var_decl) {
+  write(m_indent + "const " + type_str(var_decl.type) + " " + var_decl.name);
+  if (var_decl.init) {
+    write(" = ");
+    emit_expr(*var_decl.init);
+  }
+  write(";\n");
+}
+
+void OpenGLGLSLEmitter::emit_global_inline_interface(
+    const InlineInterfaceDecl &interface_decl, StageKind stage) {
+  if (emits_as_storage_block(interface_decl)) {
+    emit_buffer(BufferDecl{interface_decl.name, interface_decl.fields,
+                           interface_decl.annotations,
+                           interface_decl.instance_name, false});
+    return;
+  }
+
+  if (should_emit_interface(interface_decl.is_in, stage)) {
+    emit_interface_block(interface_decl.is_in, interface_decl.name,
+                         interface_decl.fields, interface_decl.instance_name);
+  }
+}
+
+void OpenGLGLSLEmitter::emit_global_interface_ref(
+    const InterfaceRef &interface_ref, const Program &program,
+    StageKind stage) {
+  if (!should_emit_interface(interface_ref.is_in, stage)) {
+    return;
+  }
+
+  if (const InterfaceDecl *interface =
+          find_interface(program, interface_ref.block_name)) {
+    emit_interface_block(interface_ref.is_in, interface->name,
+                         interface->fields, interface_ref.instance_name);
+  }
+}
+
+void OpenGLGLSLEmitter::emit_stage_resource_if_used(
+    const UniformDecl &uniform_decl, StageKind stage, const Program &program,
+    const std::unordered_set<std::string> &used_uniforms) {
+
+  if (used_uniforms.count(uniform_decl.name) &&
+      !is_shadowed(uniform_decl.name, stage, program)) {
+    emit_uniform(uniform_decl);
+  }
+}
+
+void OpenGLGLSLEmitter::emit_stage_resource_if_used(
+    const BufferDecl &buffer_decl, StageKind stage, const Program &program,
+    const std::unordered_set<std::string> &used_uniforms) {
+  if (buffer_decl.instance_name &&
+      used_uniforms.count(*buffer_decl.instance_name) &&
+      !is_shadowed(*buffer_decl.instance_name, stage, program)) {
+    emit_buffer(buffer_decl);
+  }
+}
+
+const FuncDecl *OpenGLGLSLEmitter::find_stage_entry(const Program &program,
+                                                    StageKind stage) const {
+  for (NodeID stage_id : program.stages) {
+    const auto *func_decl = std::get_if<FuncDecl>(&node(stage_id).data);
+    if (!func_decl || !func_decl->stage_kind ||
+        *func_decl->stage_kind != stage) {
+      continue;
+    }
+
+    return func_decl;
+  }
+
+  return nullptr;
+}
+
+bool OpenGLGLSLEmitter::has_uniform_annotation(const Annotations &annotations) {
+  for (const auto &annotation : annotations) {
+    if (annotation.kind == AnnotationKind::Uniform) {
+      return true;
+    }
+  }
+
+  return false;
+}
+
+bool OpenGLGLSLEmitter::interface_has_uniform_fields(
+    const InterfaceDecl &interface) const {
+  if (interface.role == InterfaceRole::Uniform) {
+    return true;
+  }
+
+  for (NodeID field_id : interface.fields) {
+    const auto &field_decl = std::get<FieldDecl>(node(field_id).data);
+    if (has_uniform_annotation(field_decl.annotations)) {
+      return true;
+    }
+  }
+
+  return false;
+}
+
+OpenGLGLSLEmitter::EntryContext
+OpenGLGLSLEmitter::build_entry_context(const Program &program, StageKind stage,
+                                       const FuncDecl &entry) const {
+  EntryContext ctx{stage};
+  const InterfaceDecl *declared_output_interface = nullptr;
+  std::unordered_set<std::string> resource_param_names;
+  std::unordered_set<std::string> used_resource_names;
+  std::unordered_set<std::string> used_input_names;
+
+  if (entry.ret.kind == TokenKind::Identifier) {
+    declared_output_interface = find_interface(program, entry.ret.name);
+    ctx.output_interface = declared_output_interface;
+  }
+
+  if (!ctx.output_interface) {
+    if (stage == StageKind::Vertex) {
+      ctx.output_interface = find_interface(program, "VertexOutput");
+    } else if (stage == StageKind::Fragment) {
+      ctx.output_interface = find_interface(program, "FragmentOutput");
+    }
+  }
+
+  if (ctx.output_interface && stage == StageKind::Fragment) {
+    std::unordered_set<std::string> used_output_names;
+
+    for (NodeID field_id : ctx.output_interface->fields) {
+      const auto &field_decl = std::get<FieldDecl>(node(field_id).data);
+      std::string alias = "_out_" + field_decl.name;
+
+      if (!used_output_names.insert(alias).second) {
+        int suffix = 0;
+        while (!used_output_names.insert(alias).second) {
+          alias = "_out_" + field_decl.name + "_" + std::to_string(++suffix);
+        }
+      }
+
+      ctx.output_aliases[field_decl.name] = alias;
+    }
+  }
+
+  if (declared_output_interface) {
+    ctx.output_local_name = find_output_local_name(
+        m_nodes, entry.body, declared_output_interface->name);
+
+    if (ctx.output_local_name && stage == StageKind::Vertex) {
+      ctx.output_instance_name = *ctx.output_local_name;
+    }
+
+    if (ctx.output_local_name) {
+      for (NodeID field_id : ctx.output_interface->fields) {
+        const auto &field_decl = std::get<FieldDecl>(node(field_id).data);
+        auto alias_it = ctx.output_aliases.find(field_decl.name);
+        std::string alias =
+            alias_it != ctx.output_aliases.end()
+                ? alias_it->second
+                : ctx.output_instance_name + "." + field_decl.name;
+        ctx.field_aliases[*ctx.output_local_name + "." + field_decl.name] =
+            alias;
+      }
+    }
+  }
+
+  for (NodeID param_id : entry.params) {
+    const auto &param_decl = std::get<ParamDecl>(node(param_id).data);
+    const InterfaceDecl *interface =
+        find_interface(program, param_decl.type.name);
+    if (!interface) {
+      continue;
+    }
+
+    if (interface_has_uniform_fields(*interface)) {
+      ctx.resource_inputs.push_back({param_decl.name, interface});
+      resource_param_names.insert(param_decl.name);
+    } else {
+      ctx.varying_inputs.push_back({param_decl.name, interface});
+    }
+  }
+
+  if (!resource_param_names.empty()) {
+    collect_resource_field_usage(m_nodes, entry.body, resource_param_names,
+                                 ctx.used_resource_fields);
+  }
+
+  for (const auto &[param_name, interface] : ctx.resource_inputs) {
+    for (NodeID field_id : interface->fields) {
+      const auto &field_decl = std::get<FieldDecl>(node(field_id).data);
+      std::string key = param_name + "." + field_decl.name;
+      if (ctx.used_resource_fields.count(key) == 0) {
+        continue;
+      }
+
+      std::string alias = "_" + field_decl.name;
+
+      if (!used_resource_names.insert(alias).second) {
+        alias = "_" + param_name + "_" + field_decl.name;
+        int suffix = 0;
+        while (!used_resource_names.insert(alias).second) {
+          alias = "_" + param_name + "_" + field_decl.name + "_" +
+                  std::to_string(++suffix);
+        }
+      }
+
+      ctx.field_aliases[key] = alias;
+      ctx.resource_aliases[key] = alias;
+    }
+  }
+
+  if (stage == StageKind::Vertex) {
+    for (const auto &[param_name, interface] : ctx.varying_inputs) {
+      for (NodeID field_id : interface->fields) {
+        const auto &field_decl = std::get<FieldDecl>(node(field_id).data);
+        std::string alias = field_decl.name;
+
+        if (!used_input_names.insert(alias).second) {
+          alias = param_name + "_" + field_decl.name;
+          int suffix = 0;
+          while (!used_input_names.insert(alias).second) {
+            alias = param_name + "_" + field_decl.name + "_" +
+                    std::to_string(++suffix);
+          }
+        }
+
+        ctx.field_aliases[param_name + "." + field_decl.name] = alias;
+      }
+    }
+  }
+
+  return ctx;
+}
+
+void OpenGLGLSLEmitter::emit_entry_signature(const EntryContext &ctx) {
+  for (const auto &[param_name, interface] : ctx.varying_inputs) {
+    if (ctx.stage == StageKind::Vertex) {
+      for (NodeID field_id : interface->fields) {
+        const auto &field_decl = std::get<FieldDecl>(node(field_id).data);
+        auto alias_it =
+            ctx.field_aliases.find(param_name + "." + field_decl.name);
+        if (alias_it == ctx.field_aliases.end()) {
+          continue;
+        }
+
+        std::string layout = layout_quals(field_decl.annotations);
+        std::string text = (layout.empty() ? "" : layout + " ") + "in " +
+                           type_str(field_decl.type) + " " + alias_it->second;
+
+        if (field_decl.array_size) {
+          text += *field_decl.array_size == 0
+                      ? "[]"
+                      : "[" + std::to_string(*field_decl.array_size) + "]";
+        }
+
+        writeln(text + ";");
+      }
+      writeln();
+    } else {
+      emit_interface_block(true, interface->name, interface->fields,
+                           param_name);
+    }
+  }
+
+  if (ctx.output_interface && ctx.stage == StageKind::Fragment) {
+    for (NodeID field_id : ctx.output_interface->fields) {
+      const auto &field_decl = std::get<FieldDecl>(node(field_id).data);
+      auto alias_it = ctx.output_aliases.find(field_decl.name);
+      if (alias_it == ctx.output_aliases.end()) {
+        continue;
+      }
+
+      std::string layout = layout_quals(field_decl.annotations);
+      std::string text = (layout.empty() ? "" : layout + " ") + "out " +
+                         type_str(field_decl.type) + " " + alias_it->second;
+
+      if (field_decl.array_size) {
+        text += *field_decl.array_size == 0
+                    ? "[]"
+                    : "[" + std::to_string(*field_decl.array_size) + "]";
+      }
+
+      writeln(text + ";");
+    }
+    writeln();
+  } else if (ctx.output_interface) {
+    emit_interface_block(false, ctx.output_interface->name,
+                         ctx.output_interface->fields,
+                         ctx.output_instance_name);
+  }
+
+  for (const auto &[param_name, interface] : ctx.resource_inputs) {
+    for (NodeID field_id : interface->fields) {
+      const auto &field_decl = std::get<FieldDecl>(node(field_id).data);
+      std::string key = param_name + "." + field_decl.name;
+      if (ctx.used_resource_fields.count(key) == 0) {
+        continue;
+      }
+
+      auto alias_it =
+          ctx.resource_aliases.find(key);
+      if (alias_it == ctx.resource_aliases.end()) {
+        continue;
+      }
+
+      emit_uniform(UniformDecl{field_decl.type, alias_it->second,
+                               field_decl.annotations, field_decl.init,
+                               field_decl.array_size});
+    }
+  }
+}
+
+void OpenGLGLSLEmitter::emit_entry_main(const FuncDecl &entry,
+                                        const EntryContext &ctx) {
+  write(m_indent + "void main() ");
+
+  const auto *body_block = std::get_if<BlockStmt>(&node(entry.body).data);
+  if (!body_block) {
+    emit_stmt(entry.body, &ctx);
+    writeln();
+    return;
+  }
+
+  write("{\n");
+  push_indent();
+  emit_output_field_initializers(ctx);
+
+  for (NodeID stmt_id : body_block->stmts) {
+    emit_stmt(stmt_id, &ctx);
+  }
+
+  pop_indent();
+  writeln("}");
+  writeln();
+}
+
+void OpenGLGLSLEmitter::emit_struct(const StructDecl &struct_decl) {
+  writeln("struct " + struct_decl.name + " {");
+  push_indent();
+  for (NodeID fid : struct_decl.fields)
+    emit_field(std::get<FieldDecl>(node(fid).data));
+  pop_indent();
+  writeln("};");
+  writeln();
+}
+
+void OpenGLGLSLEmitter::emit_uniform(const UniformDecl &uniform_decl) {
+  std::string layout = layout_quals(uniform_decl.annotations);
+  std::string prefix = layout.empty() ? "" : layout + " ";
+
+  std::string array = uniform_decl.array_size
+                          ? "[" + std::to_string(*uniform_decl.array_size) + "]"
+                          : "";
+
+  write(m_indent + prefix + "uniform " + type_str(uniform_decl.type) + " " +
+        uniform_decl.name + array);
+
+  if (uniform_decl.default_val) {
+    write(" = ");
+    emit_expr(*uniform_decl.default_val);
+  }
+
+  write(";\n");
+}
+
+void OpenGLGLSLEmitter::emit_buffer(const BufferDecl &buffer_decl) {
+  std::string layout = layout_quals(buffer_decl.annotations);
+  std::string prefix = layout.empty() ? "" : layout + " ";
+  std::string keyword = buffer_decl.is_uniform ? "uniform" : "buffer";
+  writeln(prefix + keyword + " " + buffer_decl.name + " {");
+  push_indent();
+
+  for (NodeID fid : buffer_decl.fields) {
+    emit_field(std::get<FieldDecl>(node(fid).data), false);
+  }
+
+  pop_indent();
+  writeln("} " + buffer_decl.instance_name.value_or("") + ";");
+  writeln();
+}
+
+void OpenGLGLSLEmitter::emit_interface_block(
+    bool is_in, const std::string &block_name,
+    const std::vector<NodeID> &fields,
+    const std::optional<std::string> &instance) {
+  writeln(std::string(is_in ? "in " : "out ") + block_name + " {");
+  push_indent();
+
+  for (NodeID fid : fields) {
+    emit_field(std::get<FieldDecl>(node(fid).data), false);
+  }
+
+  pop_indent();
+  writeln("} " + instance.value_or("") + ";");
+  writeln();
+}
+
+void OpenGLGLSLEmitter::emit_field(const FieldDecl &field_decl,
+                                   bool emit_initializer) {
+  std::string layout = layout_quals(field_decl.annotations);
+  write(m_indent);
+
+  if (!layout.empty()) {
+    write(layout + " ");
+  }
+
+  write(type_str(field_decl.type) + " " + field_decl.name);
+
+  if (field_decl.array_size) {
+    write(*field_decl.array_size == 0
+              ? "[]"
+              : "[" + std::to_string(*field_decl.array_size) + "]");
+  }
+
+  if (emit_initializer && field_decl.init.has_value()) {
+    write(" = ");
+    emit_expr(*field_decl.init);
+  }
+
+  write(";\n");
+}
+
+void OpenGLGLSLEmitter::emit_function_prototype(const FuncDecl &func_decl) {
+  write(m_indent + type_str(func_decl.ret) + " " + func_decl.name + "(");
+
+  for (size_t i = 0; i < func_decl.params.size(); ++i) {
+    if (i) {
+      write(", ");
+    }
+
+    emit_param(func_decl.params[i]);
+  }
+
+  write(");\n");
+}
+
+void OpenGLGLSLEmitter::emit_function(const FuncDecl &func_decl) {
+  write(m_indent + type_str(func_decl.ret) + " " + func_decl.name + "(");
+
+  for (size_t i = 0; i < func_decl.params.size(); ++i) {
+    if (i) {
+      write(", ");
+    }
+
+    emit_param(func_decl.params[i]);
+  }
+
+  write(") ");
+  emit_stmt(func_decl.body, nullptr);
+  writeln();
+}
+
+void OpenGLGLSLEmitter::emit_param(NodeID id) {
+  const auto &param_decl = std::get<ParamDecl>(node(id).data);
+
+  if (param_decl.qual != ParamQualifier::None) {
+    write(std::string(param_qual_str(param_decl.qual)) + " ");
+  }
+
+  write(type_str(param_decl.type) + " " + param_decl.name);
+}
+
+void OpenGLGLSLEmitter::emit_var_decl_stmt(const VarDecl &var_decl,
+                                           const EntryContext *ctx) {
+  if (ctx && ctx->output_local_name && ctx->output_interface &&
+      var_decl.type.kind == TokenKind::Identifier &&
+      var_decl.type.name == ctx->output_interface->name &&
+      var_decl.name == *ctx->output_local_name) {
+    return;
+  }
+
+  write(m_indent);
+  if (var_decl.is_const)
+    write("const ");
+  write(type_str(var_decl.type) + " " + var_decl.name);
+  if (var_decl.init) {
+    write(" = ");
+    emit_expr(*var_decl.init, ctx);
+  }
+  write(";\n");
+}
+
+void OpenGLGLSLEmitter::emit_var_decl_for_init(const VarDecl &var_decl,
+                                               const EntryContext *ctx) {
+  if (ctx && ctx->output_local_name && ctx->output_interface &&
+      var_decl.type.kind == TokenKind::Identifier &&
+      var_decl.type.name == ctx->output_interface->name &&
+      var_decl.name == *ctx->output_local_name) {
+    return;
+  }
+
+  write(type_str(var_decl.type) + " " + var_decl.name);
+  if (var_decl.init) {
+    write(" = ");
+    emit_expr(*var_decl.init, ctx);
+  }
+}
+
+void OpenGLGLSLEmitter::emit_output_field_initializers(
+    const EntryContext &ctx) {
+  if (!ctx.output_interface) {
+    return;
+  }
+
+  for (NodeID field_id : ctx.output_interface->fields) {
+    const auto &field_decl = std::get<FieldDecl>(node(field_id).data);
+    if (!field_decl.init) {
+      continue;
+    }
+
+    auto alias_it = ctx.output_aliases.find(field_decl.name);
+    std::string output_target =
+        alias_it != ctx.output_aliases.end()
+            ? alias_it->second
+            : ctx.output_instance_name + "." + field_decl.name;
+
+    write(m_indent + output_target + " = ");
+    emit_expr(*field_decl.init, &ctx);
+    write(";\n");
+  }
+}
+
+const VarDecl *OpenGLGLSLEmitter::find_var_decl(NodeID id) const {
+  const ASTNode *current_node = &node(id);
+  if (const auto *decl_stmt = std::get_if<DeclStmt>(&current_node->data)) {
+    current_node = &node(decl_stmt->decl);
+  }
+
+  return std::get_if<VarDecl>(&current_node->data);
+}
+
+bool OpenGLGLSLEmitter::try_emit_output_fields(const std::vector<NodeID> &args,
+                                               const EntryContext &ctx) {
+  if (!ctx.output_interface ||
+      args.size() > ctx.output_interface->fields.size()) {
+    return false;
+  }
+
+  for (size_t i = 0; i < ctx.output_interface->fields.size(); ++i) {
+    const auto &field_decl =
+        std::get<FieldDecl>(node(ctx.output_interface->fields[i]).data);
+    if (i < args.size()) {
+      auto alias_it = ctx.output_aliases.find(field_decl.name);
+      std::string output_target =
+          alias_it != ctx.output_aliases.end()
+              ? alias_it->second
+              : ctx.output_instance_name + "." + field_decl.name;
+
+      write(m_indent + output_target + " = ");
+      emit_expr(args[i], &ctx);
+      write(";\n");
+      continue;
+    }
+
+    if (!field_decl.init) {
+      return false;
+    }
+  }
+
+  write(m_indent + "return;\n");
+  return true;
+}
+
+bool OpenGLGLSLEmitter::try_emit_structured_return(const ReturnStmt &stmt,
+                                                   const EntryContext *ctx) {
+  if (!ctx || !ctx->output_interface || !stmt.value) {
+    return false;
+  }
+
+  const auto &return_node = node(*stmt.value);
+
+  if (const auto *identifier_expr = std::get_if<IdentifierExpr>(&return_node.data)) {
+    if (ctx->output_local_name &&
+        identifier_expr->name == *ctx->output_local_name) {
+      write(m_indent + "return;\n");
+      return true;
+    }
+  }
+
+  if (const auto *construct_expr =
+          std::get_if<ConstructExpr>(&return_node.data)) {
+    return ctx->output_interface->name == construct_expr->type.name &&
+           try_emit_output_fields(construct_expr->args, *ctx);
+  }
+
+  if (const auto *call_expr = std::get_if<CallExpr>(&return_node.data)) {
+    const auto &callee_node = node(call_expr->callee);
+    if (const auto *callee_ident =
+            std::get_if<IdentifierExpr>(&callee_node.data)) {
+      return callee_ident->name == ctx->output_interface->name &&
+             try_emit_output_fields(call_expr->args, *ctx);
+    }
+
+    if (const auto *callee_ref =
+            std::get_if<UnresolvedRef>(&callee_node.data)) {
+      return callee_ref->name == ctx->output_interface->name &&
+             try_emit_output_fields(call_expr->args, *ctx);
+    }
+  }
+
+  return false;
+}
+
+void OpenGLGLSLEmitter::emit_stmt_node(const BlockStmt &stmt,
+                                       const EntryContext *ctx) {
+  write("{\n");
+  push_indent();
+
+  for (NodeID sid : stmt.stmts) {
+    emit_stmt(sid, ctx);
+  }
+
+  pop_indent();
+  write(m_indent + "}\n");
+}
+
+void OpenGLGLSLEmitter::emit_stmt_node(const IfStmt &stmt,
+                                       const EntryContext *ctx) {
+  write(m_indent + "if (");
+  emit_expr(stmt.cond, ctx);
+  write(") ");
+  emit_body_stmt(stmt.then_br, ctx);
+
+  if (stmt.else_br) {
+    write(m_indent + "else ");
+    emit_body_stmt(*stmt.else_br, ctx);
+  }
+}
+
+void OpenGLGLSLEmitter::emit_stmt_node(const ForStmt &stmt,
+                                       const EntryContext *ctx) {
+  write(m_indent + "for (");
+  emit_for_init(stmt.init, ctx);
+  write(" ");
+
+  if (stmt.cond) {
+    emit_expr(*stmt.cond, ctx);
+  }
+
+  write("; ");
+
+  if (stmt.step) {
+    emit_expr(*stmt.step, ctx);
+  }
+
+  write(") ");
+  emit_body_stmt(stmt.body, ctx);
+}
+
+void OpenGLGLSLEmitter::emit_stmt_node(const WhileStmt &stmt,
+                                       const EntryContext *ctx) {
+  write(m_indent + "while (");
+  emit_expr(stmt.cond, ctx);
+  write(") ");
+  emit_body_stmt(stmt.body, ctx);
+}
+
+void OpenGLGLSLEmitter::emit_stmt_node(const ReturnStmt &stmt,
+                                       const EntryContext *ctx) {
+  if (try_emit_structured_return(stmt, ctx)) {
+    return;
+  }
+
+  write(m_indent + "return");
+  if (stmt.value) {
+    write(" ");
+    emit_expr(*stmt.value, ctx);
+  }
+  write(";\n");
+}
+
+void OpenGLGLSLEmitter::emit_stmt_node(const ExprStmt &stmt,
+                                       const EntryContext *ctx) {
+  write(m_indent);
+  emit_expr(stmt.expr, ctx);
+  write(";\n");
+}
+
+void OpenGLGLSLEmitter::emit_stmt_node(const DeclStmt &stmt,
+                                       const EntryContext *ctx) {
+  emit_var_decl_stmt(std::get<VarDecl>(node(stmt.decl).data), ctx);
+}
+
+void OpenGLGLSLEmitter::emit_stmt_node(const VarDecl &stmt,
+                                       const EntryContext *ctx) {
+  emit_var_decl_stmt(stmt, ctx);
+}
+
+void OpenGLGLSLEmitter::emit_stmt_node(const BreakStmt &,
+                                       const EntryContext *) {
+  writeln("break;");
+}
+
+void OpenGLGLSLEmitter::emit_stmt_node(const ContinueStmt &,
+                                       const EntryContext *) {
+  writeln("continue;");
+}
+
+void OpenGLGLSLEmitter::emit_stmt_node(const DiscardStmt &,
+                                       const EntryContext *) {
+  writeln("discard;");
+}
+
+void OpenGLGLSLEmitter::emit_body_stmt(NodeID id, const EntryContext *ctx) {
+  if (std::holds_alternative<BlockStmt>(node(id).data)) {
+    emit_stmt(id, ctx);
+  } else {
+    write("{\n");
+    push_indent();
+    emit_stmt(id, ctx);
+    pop_indent();
+    write(m_indent + "}\n");
+  }
+}
+
+void OpenGLGLSLEmitter::emit_for_init(NodeID id, const EntryContext *ctx) {
+  if (const VarDecl *var_decl = find_var_decl(id)) {
+    emit_var_decl_for_init(*var_decl, ctx);
+    write(";");
+    return;
+  }
+
+  if (const auto *expr_stmt = std::get_if<ExprStmt>(&node(id).data)) {
+    emit_expr(expr_stmt->expr, ctx);
+    write(";");
+    return;
+  }
+
+  write(";");
+}
+
+void OpenGLGLSLEmitter::emit_stmt(NodeID id, const EntryContext *ctx) {
+  const auto stmt_emitter =
+      Overloaded{[&](const BlockStmt &stmt) { emit_stmt_node(stmt, ctx); },
+                 [&](const IfStmt &stmt) { emit_stmt_node(stmt, ctx); },
+                 [&](const ForStmt &stmt) { emit_stmt_node(stmt, ctx); },
+                 [&](const WhileStmt &stmt) { emit_stmt_node(stmt, ctx); },
+                 [&](const ReturnStmt &stmt) { emit_stmt_node(stmt, ctx); },
+                 [&](const ExprStmt &stmt) { emit_stmt_node(stmt, ctx); },
+                 [&](const DeclStmt &stmt) { emit_stmt_node(stmt, ctx); },
+                 [&](const VarDecl &stmt) { emit_stmt_node(stmt, ctx); },
+                 [&](const BreakStmt &stmt) { emit_stmt_node(stmt, ctx); },
+                 [&](const ContinueStmt &stmt) { emit_stmt_node(stmt, ctx); },
+                 [&](const DiscardStmt &stmt) { emit_stmt_node(stmt, ctx); },
+                 [&](const auto &) {}};
+
+  std::visit(stmt_emitter, node(id).data);
+}
+
+void OpenGLGLSLEmitter::emit_expr_paren(NodeID id, const EntryContext *ctx) {
+  bool needs = std::holds_alternative<BinaryExpr>(node(id).data) ||
+               std::holds_alternative<TernaryExpr>(node(id).data);
+  if (needs)
+    write("(");
+  emit_expr(id, ctx);
+  if (needs)
+    write(")");
+}
+
+void OpenGLGLSLEmitter::emit_literal(const LiteralExpr &expr) {
+  const auto literal_emitter = Overloaded{
+      [&](bool value) { write(value ? "true" : "false"); },
+      [&](int64_t value) { write(std::to_string(value)); },
+      [&](double value) {
+        char buf[32];
+        std::snprintf(buf, sizeof(buf), "%g", static_cast<double>(value));
+        write(buf);
+      }};
+
+  std::visit(literal_emitter, expr.value);
+}
+
+void OpenGLGLSLEmitter::emit_call_args(const std::vector<NodeID> &args,
+                                       const EntryContext *ctx) {
+  for (size_t i = 0; i < args.size(); ++i) {
+    if (i)
+      write(", ");
+    emit_expr(args[i], ctx);
+  }
+}
+
+bool OpenGLGLSLEmitter::try_emit_field_alias(const FieldExpr &expr,
+                                             const EntryContext *ctx) {
+  if (!ctx) {
+    return false;
+  }
+
+  if (const auto *identifier_expr =
+          std::get_if<IdentifierExpr>(&node(expr.object).data)) {
+    auto alias_it =
+        ctx->field_aliases.find(identifier_expr->name + "." + expr.field);
+    if (alias_it != ctx->field_aliases.end()) {
+      write(alias_it->second);
+      return true;
+    }
+  }
+
+  return false;
+}
+
+void OpenGLGLSLEmitter::emit_expr_node(const LiteralExpr &expr,
+                                       const EntryContext *) {
+  emit_literal(expr);
+}
+
+void OpenGLGLSLEmitter::emit_expr_node(const IdentifierExpr &expr,
+                                       const EntryContext *) {
+  write(expr.name);
+}
+
+void OpenGLGLSLEmitter::emit_expr_node(const UnresolvedRef &expr,
+                                       const EntryContext *) {
+  write(expr.name);
+}
+
+void OpenGLGLSLEmitter::emit_expr_node(const BinaryExpr &expr,
+                                       const EntryContext *ctx) {
+  emit_expr_paren(expr.lhs, ctx);
+  write(" ");
+  write(op_str(expr.op));
+  write(" ");
+  emit_expr_paren(expr.rhs, ctx);
+}
+
+void OpenGLGLSLEmitter::emit_expr_node(const UnaryExpr &expr,
+                                       const EntryContext *ctx) {
+  if (expr.prefix) {
+    write(op_str(expr.op));
+    emit_expr(expr.operand, ctx);
+  } else {
+    emit_expr(expr.operand, ctx);
+    write(op_str(expr.op));
+  }
+}
+
+void OpenGLGLSLEmitter::emit_expr_node(const TernaryExpr &expr,
+                                       const EntryContext *ctx) {
+  emit_expr(expr.cond, ctx);
+  write(" ? ");
+  emit_expr(expr.then_expr, ctx);
+  write(" : ");
+  emit_expr(expr.else_expr, ctx);
+}
+
+void OpenGLGLSLEmitter::emit_expr_node(const CallExpr &expr,
+                                       const EntryContext *ctx) {
+  emit_expr(expr.callee, ctx);
+  write("(");
+  emit_call_args(expr.args, ctx);
+  write(")");
+}
+
+void OpenGLGLSLEmitter::emit_expr_node(const IndexExpr &expr,
+                                       const EntryContext *ctx) {
+  emit_expr(expr.array, ctx);
+  write("[");
+  emit_expr(expr.index, ctx);
+  write("]");
+}
+
+void OpenGLGLSLEmitter::emit_expr_node(const FieldExpr &expr,
+                                       const EntryContext *ctx) {
+  if (try_emit_field_alias(expr, ctx)) {
+    return;
+  }
+
+  emit_expr(expr.object, ctx);
+  write(".");
+  write(expr.field);
+}
+
+void OpenGLGLSLEmitter::emit_expr_node(const ConstructExpr &expr,
+                                       const EntryContext *ctx) {
+  write(type_str(expr.type));
+  write("(");
+  emit_call_args(expr.args, ctx);
+  write(")");
+}
+
+void OpenGLGLSLEmitter::emit_expr_node(const AssignExpr &expr,
+                                       const EntryContext *ctx) {
+  emit_expr(expr.lhs, ctx);
+  write(" ");
+  write(op_str(expr.op));
+  write(" ");
+  emit_expr(expr.rhs, ctx);
+}
+
+void OpenGLGLSLEmitter::emit_expr(NodeID id, const EntryContext *ctx) {
+  const auto expr_emitter =
+      Overloaded{[&](const LiteralExpr &expr) { emit_expr_node(expr, ctx); },
+                 [&](const IdentifierExpr &expr) { emit_expr_node(expr, ctx); },
+                 [&](const UnresolvedRef &expr) { emit_expr_node(expr, ctx); },
+                 [&](const BinaryExpr &expr) { emit_expr_node(expr, ctx); },
+                 [&](const UnaryExpr &expr) { emit_expr_node(expr, ctx); },
+                 [&](const TernaryExpr &expr) { emit_expr_node(expr, ctx); },
+                 [&](const CallExpr &expr) { emit_expr_node(expr, ctx); },
+                 [&](const IndexExpr &expr) { emit_expr_node(expr, ctx); },
+                 [&](const FieldExpr &expr) { emit_expr_node(expr, ctx); },
+                 [&](const ConstructExpr &expr) { emit_expr_node(expr, ctx); },
+                 [&](const AssignExpr &expr) { emit_expr_node(expr, ctx); },
+                 [&](const auto &) {}};
+
+  std::visit(expr_emitter, node(id).data);
+}
+
+std::string
+OpenGLGLSLEmitter::layout_quals(const Annotations &annotations) const {
+  std::string parts;
+  auto append = [&](std::string s) {
+    if (!parts.empty())
+      parts += ", ";
+    parts += std::move(s);
+  };
+
+  for (const auto &annotation : annotations) {
+    switch (annotation.kind) {
+      case AnnotationKind::Location:
+        if (annotation.slot >= 0)
+          append("location = " + std::to_string(annotation.slot));
+        break;
+      case AnnotationKind::Binding:
+        if (annotation.slot >= 0)
+          append("binding = " + std::to_string(annotation.slot));
+        break;
+      case AnnotationKind::Std430:
+        append("std430");
+        break;
+      case AnnotationKind::Std140:
+        append("std140");
+        break;
+      default:
+        break;
+    }
+  }
+  return parts.empty() ? "" : "layout(" + parts + ")";
+}
+
+std::string OpenGLGLSLEmitter::type_str(const TypeRef &type_ref) const {
+  switch (type_ref.kind) {
+    case TokenKind::KeywordVoid:
+      return "void";
+    case TokenKind::TypeBool:
+      return "bool";
+    case TokenKind::TypeInt:
+      return "int";
+    case TokenKind::TypeUint:
+      return "uint";
+    case TokenKind::TypeFloat:
+      return "float";
+    case TokenKind::TypeVec2:
+      return "vec2";
+    case TokenKind::TypeVec3:
+      return "vec3";
+    case TokenKind::TypeVec4:
+      return "vec4";
+    case TokenKind::TypeIvec2:
+      return "ivec2";
+    case TokenKind::TypeIvec3:
+      return "ivec3";
+    case TokenKind::TypeIvec4:
+      return "ivec4";
+    case TokenKind::TypeUvec2:
+      return "uvec2";
+    case TokenKind::TypeUvec3:
+      return "uvec3";
+    case TokenKind::TypeUvec4:
+      return "uvec4";
+    case TokenKind::TypeMat2:
+      return "mat2";
+    case TokenKind::TypeMat3:
+      return "mat3";
+    case TokenKind::TypeMat4:
+      return "mat4";
+    case TokenKind::TypeSampler2D:
+      return "sampler2D";
+    case TokenKind::TypeSamplerCube:
+      return "samplerCube";
+    case TokenKind::TypeSampler2DShadow:
+      return "sampler2DShadow";
+    case TokenKind::TypeIsampler2D:
+      return "isampler2D";
+    case TokenKind::TypeUsampler2D:
+      return "usampler2D";
+    case TokenKind::Identifier:
+      return type_ref.name;
+    default:
+      return "<?>";
+  }
+}
+
+std::string_view OpenGLGLSLEmitter::op_str(TokenKind op) {
+  switch (op) {
+    case TokenKind::Plus:
+      return "+";
+    case TokenKind::Minus:
+      return "-";
+    case TokenKind::Star:
+      return "*";
+    case TokenKind::Slash:
+      return "/";
+    case TokenKind::Percent:
+      return "%";
+    case TokenKind::Eq:
+      return "=";
+    case TokenKind::EqEq:
+      return "==";
+    case TokenKind::Bang:
+      return "!";
+    case TokenKind::BangEq:
+      return "!=";
+    case TokenKind::Lt:
+      return "<";
+    case TokenKind::Gt:
+      return ">";
+    case TokenKind::LtEq:
+      return "<=";
+    case TokenKind::GtEq:
+      return ">=";
+    case TokenKind::AmpAmp:
+      return "&&";
+    case TokenKind::PipePipe:
+      return "||";
+    case TokenKind::Amp:
+      return "&";
+    case TokenKind::Pipe:
+      return "|";
+    case TokenKind::Caret:
+      return "^";
+    case TokenKind::Tilde:
+      return "~";
+    case TokenKind::LtLt:
+      return "<<";
+    case TokenKind::GtGt:
+      return ">>";
+    case TokenKind::PlusEq:
+      return "+=";
+    case TokenKind::MinusEq:
+      return "-=";
+    case TokenKind::StarEq:
+      return "*=";
+    case TokenKind::SlashEq:
+      return "/=";
+    case TokenKind::PercentEq:
+      return "%=";
+    case TokenKind::AmpEq:
+      return "&=";
+    case TokenKind::PipeEq:
+      return "|=";
+    case TokenKind::CaretEq:
+      return "^=";
+    case TokenKind::LtLtEq:
+      return "<<=";
+    case TokenKind::GtGtEq:
+      return ">>=";
+    case TokenKind::PlusPlus:
+      return "++";
+    case TokenKind::MinusMinus:
+      return "--";
+    default:
+      return "?";
+  }
+}
+
+std::string_view OpenGLGLSLEmitter::param_qual_str(ParamQualifier qualifier) {
+  switch (qualifier) {
+    case ParamQualifier::In:
+      return "in";
+    case ParamQualifier::Out:
+      return "out";
+    case ParamQualifier::Inout:
+      return "inout";
+    case ParamQualifier::Const:
+      return "const";
+    default:
+      return "";
+  }
+}
+
+const InterfaceDecl *
+OpenGLGLSLEmitter::find_interface(const Program &program,
+                                  const std::string &name) const {
+  for (NodeID gid : program.globals) {
+    if (const auto *id = std::get_if<InterfaceDecl>(&node(gid).data)) {
+      if (id->name == name) {
+        return id;
+      }
+    }
+  }
+
+  return nullptr;
+}
+
+bool OpenGLGLSLEmitter::is_shadowed(const std::string &name, StageKind kind,
+                                    const Program &program) const {
+  for (NodeID stage_id : program.stages) {
+    const auto *func_decl = std::get_if<FuncDecl>(&node(stage_id).data);
+    if (!func_decl || !func_decl->stage_kind ||
+        *func_decl->stage_kind != kind) {
+      continue;
+    }
+
+    for (NodeID param_id : func_decl->params) {
+      const auto &param_decl = std::get<ParamDecl>(node(param_id).data);
+      if (param_decl.name == name) {
+        return true;
+      }
+    }
+  }
+
+  return false;
+}
+
+} // namespace astralix

--- a/src/modules/renderer/shader-lang/emitters/opengl-glsl-emitter.hpp
+++ b/src/modules/renderer/shader-lang/emitters/opengl-glsl-emitter.hpp
@@ -1,0 +1,134 @@
+#pragma once
+#include "shader-lang/ast.hpp"
+#include <string>
+#include <string_view>
+#include <unordered_map>
+#include <unordered_set>
+#include <vector>
+
+namespace astralix {
+
+class OpenGLGLSLEmitter {
+public:
+  explicit OpenGLGLSLEmitter(const std::vector<ASTNode> &nodes);
+
+  std::string emit(const Program &program, StageKind stage,
+                   const std::unordered_set<std::string> &used_uniforms);
+
+private:
+  struct InterfaceBinding {
+    std::string param_name;
+    const InterfaceDecl *interface_decl = nullptr;
+  };
+
+  struct EntryContext {
+    StageKind stage;
+    std::string output_instance_name = "_stage_out";
+    const InterfaceDecl *output_interface = nullptr;
+    std::optional<std::string> output_local_name;
+    std::vector<InterfaceBinding> varying_inputs;
+    std::vector<InterfaceBinding> resource_inputs;
+    std::unordered_set<std::string> used_resource_fields;
+    std::unordered_map<std::string, std::string> field_aliases;
+    std::unordered_map<std::string, std::string> output_aliases;
+    std::unordered_map<std::string, std::string> resource_aliases;
+  };
+
+  void emit_globals(const Program &prog, StageKind stage,
+                    const std::unordered_set<std::string> &used_uniforms,
+                    const FuncDecl *entry, const EntryContext *ctx);
+  void emit_entry_signature(const EntryContext &ctx);
+  void emit_entry_main(const FuncDecl &entry, const EntryContext &ctx);
+  EntryContext build_entry_context(const Program &program, StageKind stage,
+                                   const FuncDecl &entry) const;
+  const FuncDecl *find_stage_entry(const Program &program,
+                                   StageKind stage) const;
+  bool is_shadowed(const std::string &name, StageKind kind,
+                   const Program &prog) const;
+  bool interface_has_uniform_fields(const InterfaceDecl &iface) const;
+  static bool has_uniform_annotation(const Annotations &annotations);
+
+  void emit_struct(const StructDecl &d);
+  void emit_uniform(const UniformDecl &d);
+  void emit_buffer(const BufferDecl &d);
+  void emit_function_prototype(const FuncDecl &d);
+  void emit_function(const FuncDecl &d);
+  void emit_field(const FieldDecl &f, bool emit_initializer = true);
+  void emit_global_var(const VarDecl &d);
+  void emit_global_inline_interface(const InlineInterfaceDecl &d,
+                                    StageKind stage);
+  void emit_global_interface_ref(const InterfaceRef &d, const Program &prog,
+                                 StageKind stage);
+  void emit_stage_resource_if_used(
+      const UniformDecl &d, StageKind stage, const Program &prog,
+      const std::unordered_set<std::string> &used_uniforms);
+  void emit_stage_resource_if_used(
+      const BufferDecl &d, StageKind stage, const Program &prog,
+      const std::unordered_set<std::string> &used_uniforms);
+  void emit_interface_block(bool is_in, const std::string &block_name,
+                            const std::vector<NodeID> &fields,
+                            const std::optional<std::string> &inst);
+  void emit_param(NodeID id);
+  void emit_var_decl_stmt(const VarDecl &d, const EntryContext *ctx);
+  void emit_var_decl_for_init(const VarDecl &d, const EntryContext *ctx);
+  void emit_output_field_initializers(const EntryContext &ctx);
+  const VarDecl *find_var_decl(NodeID id) const;
+  bool try_emit_structured_return(const ReturnStmt &stmt,
+                                  const EntryContext *ctx);
+  bool try_emit_output_fields(const std::vector<NodeID> &args,
+                              const EntryContext &ctx);
+
+  void emit_stmt_node(const BlockStmt &stmt, const EntryContext *ctx);
+  void emit_stmt_node(const IfStmt &stmt, const EntryContext *ctx);
+  void emit_stmt_node(const ForStmt &stmt, const EntryContext *ctx);
+  void emit_stmt_node(const WhileStmt &stmt, const EntryContext *ctx);
+  void emit_stmt_node(const ReturnStmt &stmt, const EntryContext *ctx);
+  void emit_stmt_node(const ExprStmt &stmt, const EntryContext *ctx);
+  void emit_stmt_node(const DeclStmt &stmt, const EntryContext *ctx);
+  void emit_stmt_node(const VarDecl &stmt, const EntryContext *ctx);
+  void emit_stmt_node(const BreakStmt &stmt, const EntryContext *ctx);
+  void emit_stmt_node(const ContinueStmt &stmt, const EntryContext *ctx);
+  void emit_stmt_node(const DiscardStmt &stmt, const EntryContext *ctx);
+
+  void emit_stmt(NodeID id, const EntryContext *ctx = nullptr);
+  void emit_body_stmt(NodeID id, const EntryContext *ctx = nullptr);
+  void emit_for_init(NodeID id, const EntryContext *ctx = nullptr);
+  void emit_literal(const LiteralExpr &expr);
+  void emit_call_args(const std::vector<NodeID> &args,
+                      const EntryContext *ctx = nullptr);
+  bool try_emit_field_alias(const FieldExpr &expr,
+                            const EntryContext *ctx = nullptr);
+  void emit_expr_node(const LiteralExpr &expr, const EntryContext *ctx);
+  void emit_expr_node(const IdentifierExpr &expr, const EntryContext *ctx);
+  void emit_expr_node(const UnresolvedRef &expr, const EntryContext *ctx);
+  void emit_expr_node(const BinaryExpr &expr, const EntryContext *ctx);
+  void emit_expr_node(const UnaryExpr &expr, const EntryContext *ctx);
+  void emit_expr_node(const TernaryExpr &expr, const EntryContext *ctx);
+  void emit_expr_node(const CallExpr &expr, const EntryContext *ctx);
+  void emit_expr_node(const IndexExpr &expr, const EntryContext *ctx);
+  void emit_expr_node(const FieldExpr &expr, const EntryContext *ctx);
+  void emit_expr_node(const ConstructExpr &expr, const EntryContext *ctx);
+  void emit_expr_node(const AssignExpr &expr, const EntryContext *ctx);
+  void emit_expr(NodeID id, const EntryContext *ctx = nullptr);
+  void emit_expr_paren(NodeID id, const EntryContext *ctx = nullptr);
+
+  std::string layout_quals(const Annotations &annots) const;
+  std::string type_str(const TypeRef &t) const;
+  static std::string_view op_str(TokenKind op);
+  static std::string_view param_qual_str(ParamQualifier q);
+
+  const InterfaceDecl *find_interface(const Program &prog,
+                                      const std::string &name) const;
+  const ASTNode &node(NodeID id) const;
+
+  void push_indent();
+  void pop_indent();
+  void writeln(std::string_view text = {});
+  void write(std::string_view text);
+
+  const std::vector<ASTNode> &m_nodes;
+  std::string m_out;
+  std::string m_indent;
+};
+
+} // namespace astralix

--- a/src/modules/renderer/shader-lang/linker.cpp
+++ b/src/modules/renderer/shader-lang/linker.cpp
@@ -1,0 +1,461 @@
+#include "shader-lang/linker.hpp"
+#include "shader-lang/diagnostics.hpp"
+#include "shader-lang/parser.hpp"
+#include "shader-lang/tokenizer.hpp"
+#include <fstream>
+#include <sstream>
+#include <string>
+#include <unordered_set>
+#include <vector>
+
+namespace astralix {
+
+static std::pair<std::vector<Token>, std::vector<std::string>>
+tokenize_source(std::string_view src, std::string_view filename = "") {
+  Tokenizer tokenizer(src, filename);
+  std::vector<Token> tokens;
+
+  while (true) {
+    Token token = tokenizer.next();
+    tokens.push_back(token);
+    if (token.kind == TokenKind::EoF)
+      break;
+  }
+
+  return {std::move(tokens), tokenizer.errors()};
+}
+
+static void offset_node_ids(std::vector<ASTNode> &nodes, NodeID offset_id) {
+  for (auto &node : nodes) {
+    node.id += offset_id;
+    std::visit([offset_id](auto &decl) { decl.visit_offset(offset_id); },
+               node.data);
+  }
+}
+
+static NodeID unwrap_decl_stmt(NodeID id, const std::vector<ASTNode> &nodes) {
+  if (const auto *decl_stmt = std::get_if<DeclStmt>(&nodes[id].data)) {
+    return decl_stmt->decl;
+  }
+
+  return id;
+}
+
+struct DeclarationRegistry {
+  std::unordered_set<std::string> &declared;
+  ScopeInfo &scopes;
+  std::optional<StageKind> stage_kind;
+
+  void register_uniform_name(const std::string &name) const {
+    if (stage_kind) {
+      scopes.stage_uniforms[*stage_kind].insert(name);
+    } else {
+      scopes.global_uniforms.insert(name);
+    }
+
+    declared.insert(name);
+  }
+
+  void operator()(const FuncDecl &declaration) const {
+    declared.insert(declaration.name);
+  }
+
+  void operator()(const StructDecl &declaration) const {
+    declared.insert(declaration.name);
+  }
+
+  void operator()(const VarDecl &declaration) const {
+    if (!stage_kind) {
+      declared.insert(declaration.name);
+    }
+  }
+
+  void operator()(const InterfaceDecl &declaration) const {
+    if (!stage_kind) {
+      declared.insert(declaration.name);
+    }
+  }
+
+  void operator()(const InlineInterfaceDecl &declaration) const {
+    if (declaration.instance_name) {
+      declared.insert(*declaration.instance_name);
+    }
+  }
+
+  void operator()(const InterfaceRef &declaration) const {
+    if (declaration.instance_name) {
+      declared.insert(*declaration.instance_name);
+    }
+  }
+
+  void operator()(const UniformDecl &declaration) const {
+    register_uniform_name(declaration.name);
+  }
+
+  void operator()(const BufferDecl &declaration) const {
+    if (declaration.instance_name) {
+      register_uniform_name(*declaration.instance_name);
+    }
+  }
+
+  template <class T> void operator()(const T &) const {}
+};
+
+static void
+validate_base_identifier(LinkResult &result, const ASTNode &base_node,
+                         const std::unordered_set<std::string> &declared,
+                         const std::unordered_set<std::string> &glsl_builtins,
+                         const std::unordered_set<std::string> &local_vars) {
+  const auto *identifier_expr = std::get_if<IdentifierExpr>(&base_node.data);
+  if (!identifier_expr) {
+    return;
+  }
+
+  if (!declared.count(identifier_expr->name) &&
+      !glsl_builtins.count(identifier_expr->name) &&
+      !local_vars.count(identifier_expr->name)) {
+    PUSH_UNDEFINED_IDENTIFIER(result, identifier_expr->name,
+                              base_node.location);
+  }
+}
+
+static const InterfaceDecl *
+find_interface_decl(const Program &program, const std::vector<ASTNode> &nodes,
+                    std::string_view name) {
+  for (NodeID global : program.globals) {
+    const auto *interface_decl = std::get_if<InterfaceDecl>(&nodes[global].data);
+    if (interface_decl && interface_decl->name == name) {
+      return interface_decl;
+    }
+  }
+
+  return nullptr;
+}
+
+static const InterfaceDecl *
+find_declared_output_interface(const Program &program,
+                               const std::vector<ASTNode> &nodes,
+                               const FuncDecl &func_decl) {
+  if (func_decl.ret.kind != TokenKind::Identifier) {
+    return nullptr;
+  }
+
+  return find_interface_decl(program, nodes, func_decl.ret.name);
+}
+
+static bool is_output_interface_local(const ASTNode &node,
+                                      std::string_view interface_name) {
+  const auto *var_decl = std::get_if<VarDecl>(&node.data);
+  return var_decl && var_decl->type.kind == TokenKind::Identifier &&
+         var_decl->type.name == interface_name;
+}
+
+static void push_output_local_error(LinkResult &result, const ASTNode &node,
+                                    std::string message) {
+  result.errors.push_back(format_located_error(std::move(message), node.location));
+}
+
+template <class Fn>
+static void visit_subtree(NodeID id, const std::vector<ASTNode> &nodes,
+                          std::optional<NodeID> parent_id, Fn &fn) {
+  fn(id, parent_id);
+  visit_child_ids(nodes[id], [&](NodeID child_id) {
+    visit_subtree(child_id, nodes, id, fn);
+  });
+}
+
+static void validate_output_local_usage(LinkResult &result,
+                                        const Program &program,
+                                        const FuncDecl &func_decl,
+                                        const std::vector<ASTNode> &nodes) {
+  const InterfaceDecl *output_interface =
+      find_declared_output_interface(program, nodes, func_decl);
+  if (!output_interface) {
+    return;
+  }
+
+  std::vector<NodeID> output_local_ids;
+  auto collector = [&](NodeID id, std::optional<NodeID>) {
+    if (is_output_interface_local(nodes[id], output_interface->name)) {
+      output_local_ids.push_back(id);
+    }
+  };
+  visit_subtree(func_decl.body, nodes, std::nullopt, collector);
+
+  if (output_local_ids.empty()) {
+    return;
+  }
+
+  std::unordered_set<std::string> output_local_names;
+  for (NodeID output_local_id : output_local_ids) {
+    const auto &var_decl = std::get<VarDecl>(nodes[output_local_id].data);
+    output_local_names.insert(var_decl.name);
+
+    if (var_decl.init) {
+      push_output_local_error(
+          result, nodes[output_local_id],
+          "stage entry output accumulator '" + var_decl.name +
+              "' cannot have an initializer");
+    }
+  }
+
+  if (output_local_ids.size() > 1) {
+    push_output_local_error(
+        result, nodes[output_local_ids[1]],
+        "stage entry output accumulator supports only one local of type '" +
+            output_interface->name + "'");
+  }
+
+  const auto &sink_decl = std::get<VarDecl>(nodes[output_local_ids.front()].data);
+  const std::string &sink_name = sink_decl.name;
+
+  auto validator = [&](NodeID id, std::optional<NodeID> parent_id) {
+    const auto &current_node = nodes[id];
+
+    if (const auto *assign_expr = std::get_if<AssignExpr>(&current_node.data)) {
+      if (const auto *lhs_identifier =
+              std::get_if<IdentifierExpr>(&nodes[assign_expr->lhs].data)) {
+        if (lhs_identifier->name == sink_name) {
+          push_output_local_error(
+              result, current_node,
+              "stage entry output accumulator '" + sink_name +
+                  "' cannot be assigned as a whole value");
+        }
+      }
+    }
+
+    if (const auto *return_stmt = std::get_if<ReturnStmt>(&current_node.data)) {
+      if (!return_stmt->value) {
+        return;
+      }
+
+      if (const auto *return_identifier =
+              std::get_if<IdentifierExpr>(&nodes[*return_stmt->value].data)) {
+        if (output_local_names.count(return_identifier->name) > 0 &&
+            return_identifier->name != sink_name) {
+          push_output_local_error(
+              result, current_node,
+              "stage entry output accumulator must return '" + sink_name +
+                  "', not '" + return_identifier->name + "'");
+        }
+      }
+    }
+
+    const auto *identifier_expr = std::get_if<IdentifierExpr>(&current_node.data);
+    if (!identifier_expr || identifier_expr->name != sink_name) {
+      return;
+    }
+
+    if (!parent_id) {
+      push_output_local_error(
+          result, current_node,
+          "stage entry output accumulator '" + sink_name +
+              "' can only be used via field access or 'return " + sink_name +
+              "'");
+      return;
+    }
+
+    const auto &parent_node = nodes[*parent_id];
+    if (const auto *field_expr = std::get_if<FieldExpr>(&parent_node.data)) {
+      if (field_expr->object == id) {
+        return;
+      }
+    }
+
+    if (const auto *return_stmt = std::get_if<ReturnStmt>(&parent_node.data)) {
+      if (return_stmt->value && *return_stmt->value == id) {
+        return;
+      }
+    }
+
+    if (const auto *assign_expr = std::get_if<AssignExpr>(&parent_node.data)) {
+      if (assign_expr->lhs == id) {
+        return;
+      }
+    }
+
+    push_output_local_error(
+        result, current_node,
+        "stage entry output accumulator '" + sink_name +
+            "' can only be used via field access or 'return " + sink_name +
+            "'");
+  };
+  visit_subtree(func_decl.body, nodes, std::nullopt, validator);
+}
+
+LinkResult Linker::link(Program &program, const std::vector<ASTNode> &nodes,
+                        std::string_view base_path) {
+  LinkResult result;
+
+  result.all_nodes = nodes;
+
+  for (const std::string &include_path : program.includes) {
+    std::string full_path = base_path.empty()
+                                ? include_path
+                                : std::string(base_path) + "/" + include_path;
+
+    std::ifstream include_file(full_path);
+
+    if (!include_file) {
+      PUSH_CANNOT_OPEN_INCLUDE(result, full_path);
+      return result;
+    }
+
+    std::ostringstream include_buffer;
+    include_buffer << include_file.rdbuf();
+    std::string include_src = include_buffer.str();
+
+    auto [include_tokens, include_token_errors] =
+        tokenize_source(include_src, include_path);
+
+    if (!include_token_errors.empty()) {
+      for (auto &e : include_token_errors)
+        PUSH_PREFIXED_INCLUDE_ERROR(result, include_path, e);
+      return result;
+    }
+
+    Parser include_parser(std::move(include_tokens), include_src);
+    Program inc_prog = include_parser.parse();
+    if (!include_parser.errors().empty()) {
+      for (auto &e : include_parser.errors())
+        PUSH_PREFIXED_INCLUDE_ERROR(result, include_path, e);
+      return result;
+    }
+
+    NodeID offset = static_cast<NodeID>(result.all_nodes.size());
+    auto inc_nodes = include_parser.nodes();
+    offset_node_ids(inc_nodes, offset);
+    result.all_nodes.insert(result.all_nodes.end(), inc_nodes.begin(),
+                            inc_nodes.end());
+
+    for (NodeID gid : inc_prog.globals)
+      program.globals.push_back(gid + offset);
+  }
+
+  static const std::unordered_set<std::string> glsl_builtins = {
+      "gl_Position",           "gl_PointSize",
+      "gl_ClipDistance",       "gl_VertexID",
+      "gl_InstanceID",         "gl_DrawID",
+      "gl_FragCoord",          "gl_FrontFacing",
+      "gl_PointCoord",         "gl_FragDepth",
+      "gl_SampleID",           "gl_SamplePosition",
+      "gl_SampleMaskIn",       "gl_SampleMask",
+      "gl_NumWorkGroups",      "gl_WorkGroupSize",
+      "gl_WorkGroupID",        "gl_LocalInvocationID",
+      "gl_GlobalInvocationID", "gl_LocalInvocationIndex"};
+
+  ScopeInfo scopes;
+  std::unordered_set<std::string> declared;
+
+  for (NodeID global : program.globals) {
+    std::visit(DeclarationRegistry{declared, scopes, std::nullopt},
+               result.all_nodes[global].data);
+  }
+
+  for (NodeID stage : program.stages) {
+    const auto &func_decl = std::get<FuncDecl>(result.all_nodes[stage].data);
+    if (!func_decl.stage_kind.has_value()) {
+      continue;
+    }
+    StageKind stage_kind = func_decl.stage_kind.value();
+    const auto *body_block =
+        std::get_if<BlockStmt>(&result.all_nodes[func_decl.body].data);
+
+    if (!body_block) {
+      continue;
+    }
+
+    for (NodeID item : body_block->stmts) {
+      NodeID item_node = unwrap_decl_stmt(item, result.all_nodes);
+      std::visit(DeclarationRegistry{declared, scopes, stage_kind},
+                 result.all_nodes[item_node].data);
+    }
+  }
+
+  for (NodeID stage : program.stages) {
+    const auto &func_decl = std::get<FuncDecl>(result.all_nodes[stage].data);
+    if (!func_decl.stage_kind) {
+      continue;
+    }
+
+    validate_output_local_usage(result, program, func_decl, result.all_nodes);
+
+    scan_uniform_usage(func_decl.body, *func_decl.stage_kind, result.all_nodes,
+                       scopes, result.uniform_usage);
+  }
+
+  for (const auto &node : result.all_nodes) {
+    if (const auto *unresolved_ref = std::get_if<UnresolvedRef>(&node.data)) {
+      if (!declared.count(unresolved_ref->name)) {
+        PUSH_UNRESOLVED_SYMBOL(result, unresolved_ref->name, node.location);
+      }
+    }
+  }
+
+  std::unordered_set<std::string> local_vars;
+
+  auto collect_function_locals = [&](NodeID function_id) {
+    if (std::holds_alternative<FuncDecl>(result.all_nodes[function_id].data)) {
+      collect_locals(function_id, result.all_nodes, local_vars);
+    }
+  };
+
+  for (NodeID global : program.globals) {
+    collect_function_locals(global);
+  }
+
+  for (NodeID stage : program.stages) {
+    collect_function_locals(stage);
+  }
+
+  for (const auto &node : result.all_nodes) {
+    if (const auto *field_expr = std::get_if<FieldExpr>(&node.data)) {
+      validate_base_identifier(result, result.all_nodes[field_expr->object],
+                               declared, glsl_builtins, local_vars);
+    }
+
+    if (const auto *idx = std::get_if<IndexExpr>(&node.data)) {
+      validate_base_identifier(result, result.all_nodes[idx->array], declared,
+                               glsl_builtins, local_vars);
+    }
+  }
+
+  return result;
+}
+
+void Linker::scan_uniform_usage(
+    NodeID nid, StageKind stage, const std::vector<ASTNode> &nodes,
+    const ScopeInfo &scopes,
+    std::unordered_map<StageKind, std::unordered_set<std::string>>
+        &uniform_usage) {
+  const auto &node = nodes[nid];
+
+  if (const auto *ie = std::get_if<IdentifierExpr>(&node.data)) {
+    bool is_global = scopes.global_uniforms.count(ie->name) > 0;
+    bool is_stage_uniform = scopes.stage_uniforms.count(stage) > 0 &&
+                            scopes.stage_uniforms.at(stage).count(ie->name) > 0;
+    if (is_global || is_stage_uniform) {
+      uniform_usage[stage].insert(ie->name);
+    }
+  }
+
+  visit_child_ids(node.data, [&](NodeID child) {
+    scan_uniform_usage(child, stage, nodes, scopes, uniform_usage);
+  });
+}
+
+void Linker::collect_locals(NodeID nid, const std::vector<ASTNode> &nodes,
+                            std::unordered_set<std::string> &local_vars) {
+  const auto &node = nodes[nid];
+  if (const auto *vd = std::get_if<VarDecl>(&node.data)) {
+    local_vars.insert(vd->name);
+  } else if (const auto *pd = std::get_if<ParamDecl>(&node.data)) {
+    local_vars.insert(pd->name);
+  }
+
+  visit_child_ids(node.data, [&](NodeID child) {
+    collect_locals(child, nodes, local_vars);
+  });
+}
+
+} // namespace astralix

--- a/src/modules/renderer/shader-lang/linker.hpp
+++ b/src/modules/renderer/shader-lang/linker.hpp
@@ -1,0 +1,39 @@
+#pragma once
+#include "shader-lang/ast.hpp"
+#include <string>
+#include <string_view>
+#include <unordered_map>
+#include <unordered_set>
+#include <vector>
+
+namespace astralix {
+
+struct LinkResult {
+  std::vector<ASTNode> all_nodes;
+  std::unordered_map<StageKind, std::unordered_set<std::string>> uniform_usage;
+  std::vector<std::string> errors;
+  bool ok() const { return errors.empty(); }
+};
+
+struct ScopeInfo {
+  std::unordered_set<std::string> global_uniforms;
+  std::unordered_map<StageKind, std::unordered_set<std::string>> stage_uniforms;
+};
+
+class Linker {
+public:
+  LinkResult link(Program &program, const std::vector<ASTNode> &nodes,
+                  std::string_view base_path = {});
+
+private:
+  void scan_uniform_usage(
+      NodeID nid, StageKind stage, const std::vector<ASTNode> &nodes,
+      const ScopeInfo &scopes,
+      std::unordered_map<StageKind, std::unordered_set<std::string>>
+          &uniform_usage);
+
+  void collect_locals(NodeID nid, const std::vector<ASTNode> &nodes,
+                      std::unordered_set<std::string> &local_vars);
+};
+
+} // namespace astralix

--- a/src/modules/renderer/shader-lang/parser.cpp
+++ b/src/modules/renderer/shader-lang/parser.cpp
@@ -1,0 +1,1699 @@
+#include "shader-lang/parser.hpp"
+#include "shader-lang/ast.hpp"
+#include "shader-lang/diagnostics.hpp"
+#include "shader-lang/token.hpp"
+#include <optional>
+#include <set>
+#include <unordered_map>
+#include <variant>
+
+namespace astralix {
+
+/* @INFO: Pratt parser binding powers. Each precedence level n maps to:
+ * > left_binding_power  = BINDING_POWER_L(n) = 2n-1 (
+ * >   used when the op is the left edge of a sub-expr
+ * >  )
+ * > right_binding_power = BINDING_POWER_R(n) = 2n (
+ * >    used when the op is the right edge,
+ * >    for right-associative: BINDING_POWER_R(n-1)
+ * > )
+ */
+#define BINDING_POWER_L(n) ((n) * 2 - 1)
+#define BINDING_POWER_R(n) ((n) * 2)
+
+#define PRECEDENCE_ASSIGN 1
+#define PRECEDENCE_TERNARY 2
+#define PRECEDENCE_LOGICAL_OR 3
+#define PRECEDENCE_LOGICAL_AND 4
+#define PRECEDENCE_BIT_OR 5
+#define PRECEDENCE_BIT_XOR 6
+#define PRECEDENCE_BIT_AND 7
+#define PRECEDENCE_EQUALITY 8
+#define PRECEDENCE_RELATIONAL 9
+#define PRECEDENCE_SHIFT 10
+#define PRECEDENCE_ADDITIVE 11
+#define PRECEDENCE_MULT 12
+#define PRECEDENCE_UNARY 14
+#define PRECEDENCE_POSTFIX 15
+
+static TypeRef type_from_keyword(TokenKind kind) { return TypeRef{kind, {}}; }
+
+static uint32_t token_src_length(const Token &token) {
+  if (!token.lexeme.empty()) {
+    return static_cast<uint32_t>(token.lexeme.size());
+  }
+
+  switch (token.kind) {
+    case TokenKind::LtLtEq:
+    case TokenKind::GtGtEq:
+      return 3;
+    case TokenKind::PlusPlus:
+    case TokenKind::MinusMinus:
+    case TokenKind::EqEq:
+    case TokenKind::BangEq:
+    case TokenKind::LtEq:
+    case TokenKind::GtEq:
+    case TokenKind::AmpAmp:
+    case TokenKind::PipePipe:
+    case TokenKind::LtLt:
+    case TokenKind::GtGt:
+    case TokenKind::PlusEq:
+    case TokenKind::MinusEq:
+    case TokenKind::StarEq:
+    case TokenKind::SlashEq:
+    case TokenKind::PercentEq:
+    case TokenKind::AmpEq:
+    case TokenKind::PipeEq:
+    case TokenKind::CaretEq:
+      return 2;
+    default:
+      return 1;
+  }
+}
+
+static bool
+annotation_allowed(AnnotationKind kind,
+                   std::initializer_list<AnnotationKind> allowed_kinds) {
+  for (AnnotationKind allowed_kind : allowed_kinds) {
+    if (kind == allowed_kind) {
+      return true;
+    }
+  }
+
+  return false;
+}
+
+static const Attribute *find_attribute(const AttributeList &attributes,
+                                       AttributeKind kind) {
+  for (const auto &attribute : attributes) {
+    if (attribute.kind == kind) {
+      return &attribute;
+    }
+  }
+  return nullptr;
+}
+
+static const Annotation *find_annotation(const Annotations &annotations,
+                                         AnnotationKind kind) {
+  for (const auto &annotation : annotations) {
+    if (annotation.kind == kind) {
+      return &annotation;
+    }
+  }
+  return nullptr;
+}
+
+static void validate_exclusive_attributes(std::vector<std::string> &errors,
+                                          const AttributeList &attributes,
+                                          std::string_view target,
+                                          std::string_view source,
+                                          AttributeKind lhs_kind,
+                                          AttributeKind rhs_kind) {
+  const Attribute *lhs = find_attribute(attributes, lhs_kind);
+  const Attribute *rhs = find_attribute(attributes, rhs_kind);
+
+  if (!lhs || !rhs) {
+    return;
+  }
+
+  PUSH_ATTRIBUTE_EXCLUSIVE_CONFLICT(errors, *lhs, target, source, lhs_kind);
+  PUSH_ATTRIBUTE_EXCLUSIVE_CONFLICT(errors, *rhs, target, source, rhs_kind);
+}
+
+static void validate_exclusive_annotations(std::vector<std::string> &errors,
+                                           const Annotations &annotations,
+                                           std::string_view target,
+                                           std::string_view source,
+                                           AnnotationKind lhs_kind,
+                                           AnnotationKind rhs_kind) {
+  const Annotation *lhs = find_annotation(annotations, lhs_kind);
+  const Annotation *rhs = find_annotation(annotations, rhs_kind);
+
+  if (!lhs || !rhs) {
+    return;
+  }
+
+  PUSH_ANNOTATION_EXCLUSIVE_CONFLICT(errors, *lhs, target, source, lhs_kind);
+  PUSH_ANNOTATION_EXCLUSIVE_CONFLICT(errors, *rhs, target, source, rhs_kind);
+}
+
+static void validate_allowed_annotations(
+    std::vector<std::string> &errors, const Annotations &annotations,
+    std::string_view target, std::string_view source,
+    std::initializer_list<AnnotationKind> allowed_kinds) {
+  for (const auto &annotation : annotations) {
+    if (!annotation_allowed(annotation.kind, allowed_kinds)) {
+      push_located_error(
+          errors, annotation.location,
+          format_invalid_annotation_message(
+              annotation_kind_name(annotation.kind), target, allowed_kinds),
+          source);
+    }
+  }
+}
+
+static void validate_required_annotations(
+    std::vector<std::string> &errors, const Annotations &annotations,
+    const SourceLocation &location, std::string_view target,
+    std::string_view source,
+    std::initializer_list<AnnotationKind> required_kinds) {
+  for (AnnotationKind required_kind : required_kinds) {
+    if (find_annotation(annotations, required_kind) == nullptr) {
+      push_located_error(errors, location,
+                         format_missing_required_annotation_message(
+                             annotation_kind_name(required_kind), target),
+                         source);
+    }
+  }
+}
+
+int Parser::left_binding_power(TokenKind op) {
+  switch (op) {
+    case TokenKind::Eq:
+    case TokenKind::PlusEq:
+    case TokenKind::MinusEq:
+    case TokenKind::StarEq:
+    case TokenKind::SlashEq:
+    case TokenKind::PercentEq:
+    case TokenKind::AmpEq:
+    case TokenKind::PipeEq:
+    case TokenKind::CaretEq:
+    case TokenKind::LtLtEq:
+    case TokenKind::GtGtEq:
+      return BINDING_POWER_L(PRECEDENCE_ASSIGN);
+    case TokenKind::Question:
+      return BINDING_POWER_L(PRECEDENCE_TERNARY);
+    case TokenKind::PipePipe:
+      return BINDING_POWER_L(PRECEDENCE_LOGICAL_OR);
+    case TokenKind::AmpAmp:
+      return BINDING_POWER_L(PRECEDENCE_LOGICAL_AND);
+    case TokenKind::Pipe:
+      return BINDING_POWER_L(PRECEDENCE_BIT_OR);
+    case TokenKind::Caret:
+      return BINDING_POWER_L(PRECEDENCE_BIT_XOR);
+    case TokenKind::Amp:
+      return BINDING_POWER_L(PRECEDENCE_BIT_AND);
+    case TokenKind::EqEq:
+    case TokenKind::BangEq:
+      return BINDING_POWER_L(PRECEDENCE_EQUALITY);
+    case TokenKind::Lt:
+    case TokenKind::Gt:
+    case TokenKind::LtEq:
+    case TokenKind::GtEq:
+      return BINDING_POWER_L(PRECEDENCE_RELATIONAL);
+    case TokenKind::LtLt:
+    case TokenKind::GtGt:
+      return BINDING_POWER_L(PRECEDENCE_SHIFT);
+    case TokenKind::Plus:
+    case TokenKind::Minus:
+      return BINDING_POWER_L(PRECEDENCE_ADDITIVE);
+    case TokenKind::Star:
+    case TokenKind::Slash:
+    case TokenKind::Percent:
+      return BINDING_POWER_L(PRECEDENCE_MULT);
+    case TokenKind::PlusPlus:
+    case TokenKind::MinusMinus:
+    case TokenKind::LBracket:
+    case TokenKind::Dot:
+    case TokenKind::LParen:
+      return BINDING_POWER_L(PRECEDENCE_POSTFIX);
+    default:
+      return -1;
+  }
+}
+
+int Parser::right_binding_power(TokenKind op) {
+  switch (op) {
+    case TokenKind::Eq:
+    case TokenKind::PlusEq:
+    case TokenKind::MinusEq:
+    case TokenKind::StarEq:
+    case TokenKind::SlashEq:
+    case TokenKind::PercentEq:
+    case TokenKind::AmpEq:
+    case TokenKind::PipeEq:
+    case TokenKind::CaretEq:
+    case TokenKind::LtLtEq:
+    case TokenKind::GtGtEq:
+      return BINDING_POWER_R(PRECEDENCE_ASSIGN);
+    case TokenKind::Question:
+      return BINDING_POWER_R(PRECEDENCE_TERNARY);
+    case TokenKind::PipePipe:
+      return BINDING_POWER_R(PRECEDENCE_LOGICAL_OR);
+    case TokenKind::AmpAmp:
+      return BINDING_POWER_R(PRECEDENCE_LOGICAL_AND);
+    case TokenKind::Pipe:
+      return BINDING_POWER_R(PRECEDENCE_BIT_OR);
+    case TokenKind::Caret:
+      return BINDING_POWER_R(PRECEDENCE_BIT_XOR);
+    case TokenKind::Amp:
+      return BINDING_POWER_R(PRECEDENCE_BIT_AND);
+    case TokenKind::EqEq:
+    case TokenKind::BangEq:
+      return BINDING_POWER_R(PRECEDENCE_EQUALITY);
+    case TokenKind::Lt:
+    case TokenKind::Gt:
+    case TokenKind::LtEq:
+    case TokenKind::GtEq:
+      return BINDING_POWER_R(PRECEDENCE_RELATIONAL);
+    case TokenKind::LtLt:
+    case TokenKind::GtGt:
+      return BINDING_POWER_R(PRECEDENCE_SHIFT);
+    case TokenKind::Plus:
+    case TokenKind::Minus:
+      return BINDING_POWER_R(PRECEDENCE_ADDITIVE);
+    case TokenKind::Star:
+    case TokenKind::Slash:
+    case TokenKind::Percent:
+      return BINDING_POWER_R(PRECEDENCE_MULT);
+    default:
+      return -1;
+  }
+}
+
+NodeID Parser::parse_expr(int min_bp) {
+  NodeID lhs = parse_prefix();
+
+  while (true) {
+    TokenKind op = peek().kind;
+    int left_bp = left_binding_power(op);
+
+    if (left_bp < 0 || left_bp <= min_bp) {
+      break;
+    }
+
+    SourceLocation location = peek().location;
+
+    if (op == TokenKind::Question) {
+      advance();
+      NodeID then_expr = parse_expr(0);
+      expect(TokenKind::Colon, "expected ':' in ternary expression");
+      NodeID else_expr = parse_expr(right_binding_power(op) - 1);
+      lhs = push_node(TernaryExpr{lhs, then_expr, else_expr}, location);
+      continue;
+    }
+
+    if (op == TokenKind::PlusPlus || op == TokenKind::MinusMinus) {
+      advance();
+      lhs = push_node(UnaryExpr{lhs, op, false}, location);
+      continue;
+    }
+
+    if (op == TokenKind::LBracket) {
+      advance();
+      NodeID index = parse_expr(0);
+      expect(TokenKind::RBracket, "expected ']'");
+      lhs = push_node(IndexExpr{lhs, index}, location);
+      continue;
+    }
+
+    if (op == TokenKind::Dot) {
+      advance();
+      Token field = expect_name("expected field name after '.'");
+      lhs = push_node(FieldExpr{lhs, field.lexeme}, location);
+      continue;
+    }
+
+    if (op == TokenKind::LParen) {
+      if (auto *identifier_expr =
+              std::get_if<IdentifierExpr>(&peek_node_at(lhs).data)) {
+        if (!is_declared(identifier_expr->name)) {
+          m_nodes[lhs].data = UnresolvedRef{identifier_expr->name};
+        }
+      }
+
+      advance();
+      std::vector<NodeID> args;
+      if (!check(TokenKind::RParen)) {
+        args.push_back(parse_expr(0));
+        while (match(TokenKind::Comma)) {
+          args.push_back(parse_expr(0));
+        }
+      }
+
+      expect(TokenKind::RParen, "expected ')'");
+      lhs = push_node(CallExpr{lhs, std::move(args)}, location);
+      continue;
+    }
+
+    advance();
+    NodeID rhs = parse_expr(right_binding_power(op));
+    lhs = push_node(is_assign_op(op) ? ASTNodeData(AssignExpr{lhs, rhs, op})
+                                     : ASTNodeData(BinaryExpr{lhs, rhs, op}),
+                    location);
+  }
+
+  return lhs;
+}
+
+NodeID Parser::parse_prefix() {
+  Token token = peek();
+  SourceLocation location = token.location;
+
+  switch (token.kind) {
+    case TokenKind::Int: {
+      advance();
+      return push_node(LiteralExpr{token.int_val}, location);
+    }
+    case TokenKind::Float: {
+      advance();
+      return push_node(LiteralExpr{token.float_val}, location);
+    }
+    case TokenKind::Bool: {
+      advance();
+      return push_node(LiteralExpr{token.bool_val}, location);
+    }
+    case TokenKind::Identifier: {
+      advance();
+      return push_node(IdentifierExpr{token.lexeme}, location);
+    }
+    case TokenKind::LParen: {
+      advance();
+      NodeID inner = parse_expr(0);
+      expect(TokenKind::RParen, "expected ')'");
+      return inner;
+    }
+    case TokenKind::Bang:
+    case TokenKind::Tilde:
+    case TokenKind::Minus:
+    case TokenKind::Plus:
+    case TokenKind::PlusPlus:
+    case TokenKind::MinusMinus: {
+      advance();
+      NodeID operand = parse_expr(BINDING_POWER_L(PRECEDENCE_UNARY));
+      return push_node(UnaryExpr{operand, token.kind, true}, location);
+    }
+    default: {
+      if (is_type_keyword(token.kind)) {
+        advance();
+        TypeRef type_ref = type_from_keyword(token.kind);
+
+        expect(TokenKind::LParen, "expected '(' after type constructor");
+        std::vector<NodeID> args;
+        if (!check(TokenKind::RParen)) {
+          args.push_back(parse_expr(0));
+          while (match(TokenKind::Comma)) {
+            args.push_back(parse_expr(0));
+          }
+        }
+        expect(TokenKind::RParen, "expected ')'");
+        return push_node(ConstructExpr{type_ref, std::move(args)}, location);
+      }
+      {
+        std::string prefix = location.file.empty()
+                                 ? (std::to_string(location.line) + ":" +
+                                    std::to_string(location.col) + ": ")
+                                 : (std::string(location.file) + ":" +
+                                    std::to_string(location.line) + ":" +
+                                    std::to_string(location.col) + ": ");
+        std::string err =
+            prefix + "unexpected token in expression: '" + token.lexeme + "'";
+        if (!m_source.empty())
+          err += '\n' +
+                 format_source_context(m_source, location.line, location.col);
+        m_errors.push_back(std::move(err));
+      }
+      synchronize();
+      return push_node(LiteralExpr{int64_t(0)}, location);
+    }
+  }
+}
+
+NodeID Parser::parse_stmt() {
+  switch (peek().kind) {
+    case TokenKind::LBrace: {
+      return parse_block_stmt();
+    }
+    case TokenKind::KeywordIf: {
+      return parse_if_stmt();
+    }
+    case TokenKind::KeywordFor:
+      return parse_for_stmt();
+    case TokenKind::KeywordWhile:
+      return parse_while_stmt();
+    case TokenKind::KeywordDo:
+      return parse_do_while_stmt();
+    case TokenKind::KeywordConst:
+      return parse_const_decl();
+    case TokenKind::KeywordReturn:
+      return parse_return_stmt();
+    case TokenKind::KeywordBreak: {
+      SourceLocation location = peek().location;
+      advance();
+      expect(TokenKind::Semicolon, "expected ';'");
+      return push_node(BreakStmt{}, location);
+    }
+    case TokenKind::KeywordContinue: {
+      SourceLocation location = peek().location;
+      advance();
+      expect(TokenKind::Semicolon, "expected ';'");
+      return push_node(ContinueStmt{}, location);
+    }
+    case TokenKind::KeywordDiscard: {
+      SourceLocation location = peek().location;
+      advance();
+      expect(TokenKind::Semicolon, "expected ';'");
+      return push_node(DiscardStmt{}, location);
+    }
+    default:
+      return parse_local_var_or_expr_stmt();
+  }
+}
+
+NodeID Parser::parse_if_stmt() {
+  SourceLocation location = peek().location;
+  expect(TokenKind::KeywordIf, "expected 'if'");
+  expect(TokenKind::LParen, "expected '('");
+  NodeID cond = parse_expr(0);
+  expect(TokenKind::RParen, "expected ')'");
+  NodeID then_br = parse_stmt();
+  std::optional<NodeID> else_br;
+  if (match(TokenKind::KeywordElse))
+    else_br = parse_stmt();
+  return push_node(IfStmt{cond, then_br, else_br}, location);
+}
+
+NodeID Parser::parse_for_stmt() {
+  SourceLocation location = peek().location;
+  expect(TokenKind::KeywordFor, "expected 'for'");
+  expect(TokenKind::LParen, "expected '('");
+  NodeID init = parse_local_var_or_expr_stmt(); // consumes its own ';'
+  std::optional<NodeID> cond, step;
+  if (!check(TokenKind::Semicolon))
+    cond = parse_expr(0);
+  expect(TokenKind::Semicolon, "expected ';'");
+  if (!check(TokenKind::RParen))
+    step = parse_expr(0);
+  expect(TokenKind::RParen, "expected ')'");
+  NodeID body = parse_stmt();
+  return push_node(ForStmt{init, cond, step, body}, location);
+}
+
+NodeID Parser::parse_var_decl() {
+  SourceLocation location = peek().location;
+  TypeRef ret = parse_type_ref();
+  Token name = expect_name("expected name");
+
+  // if (check(TokenKind::LParen)) {
+  //   return parse_function_decl(ret, name.lexeme, location);
+  // }
+
+  std::optional<NodeID> init;
+
+  if (match(TokenKind::Eq)) {
+    init = parse_expr(0);
+  }
+
+  expect(TokenKind::Semicolon, "expected ';'");
+  return push_node(VarDecl{ret, name.lexeme, init}, location);
+}
+
+NodeID Parser::parse_function_decl(AttributeList attributes) {
+  SourceLocation location = peek().location;
+
+  expect(TokenKind::KeywordFunction, "expected 'fn'");
+
+  Token name = expect_name("expected name");
+
+  std::optional<StageKind> stage_kind;
+
+  for (const auto &attribute : attributes) {
+    switch (attribute.kind) {
+      case AttributeKind::VertexStage:
+        stage_kind = StageKind::Vertex;
+        break;
+      case AttributeKind::GeometryStage:
+        stage_kind = StageKind::Geometry;
+        break;
+      case AttributeKind::FragmentStage:
+        stage_kind = StageKind::Fragment;
+        break;
+      case AttributeKind::ComputeStage:
+        stage_kind = StageKind::Compute;
+        break;
+      default:
+        PUSH_INVALID_ATTRIBUTE(
+            m_errors, attribute, "function declaration", m_source,
+            AttributeKind::VertexStage, AttributeKind::GeometryStage,
+            AttributeKind::FragmentStage, AttributeKind::ComputeStage);
+        break;
+    }
+  }
+
+  declare(name.lexeme);
+
+  expect(TokenKind::LParen, "expected '('");
+
+  std::vector<NodeID> params;
+
+  if (!check(TokenKind::RParen)) {
+    params.push_back(parse_param());
+    while (match(TokenKind::Comma)) {
+      params.push_back(parse_param());
+    }
+  }
+
+  expect(TokenKind::RParen, "expected ')'");
+
+  expect(TokenKind::Arrow, "expected '->'");
+
+  TypeRef ret = parse_type_ref();
+
+  NodeID body = parse_block_stmt();
+
+  return push_node(FuncDecl{ret, std::move(name.lexeme), std::move(params),
+                            body, std::move(stage_kind)},
+                   location);
+}
+
+NodeID Parser::parse_param() {
+  SourceLocation location = peek().location;
+  ParamQualifier qual = ParamQualifier::None;
+  if (match(TokenKind::KeywordIn))
+    qual = ParamQualifier::In;
+  else if (match(TokenKind::KeywordOut))
+    qual = ParamQualifier::Out;
+  else if (match(TokenKind::KeywordInout))
+    qual = ParamQualifier::Inout;
+  else if (match(TokenKind::KeywordConst))
+    qual = ParamQualifier::Const;
+  TypeRef type = parse_type_ref();
+  Token name = expect_name("expected parameter name");
+  return push_node(ParamDecl{type, name.lexeme, qual}, location);
+}
+
+void Parser::synchronize() {
+  while (!check(TokenKind::EoF)) {
+    if (peek().kind == TokenKind::Semicolon) {
+      advance();
+      return;
+    }
+    if (peek().kind == TokenKind::RBrace)
+      return;
+    advance();
+  }
+}
+
+bool Parser::is_type_keyword(TokenKind k) {
+  switch (k) {
+    case TokenKind::TypeBool:
+    case TokenKind::TypeInt:
+    case TokenKind::TypeUint:
+    case TokenKind::TypeFloat:
+    case TokenKind::TypeVec2:
+    case TokenKind::TypeVec3:
+    case TokenKind::TypeVec4:
+    case TokenKind::TypeIvec2:
+    case TokenKind::TypeIvec3:
+    case TokenKind::TypeIvec4:
+    case TokenKind::TypeUvec2:
+    case TokenKind::TypeUvec3:
+    case TokenKind::TypeUvec4:
+    case TokenKind::TypeMat2:
+    case TokenKind::TypeMat3:
+    case TokenKind::TypeMat4:
+    case TokenKind::TypeSampler2D:
+    case TokenKind::TypeSamplerCube:
+    case TokenKind::TypeSampler2DShadow:
+    case TokenKind::TypeIsampler2D:
+    case TokenKind::TypeUsampler2D:
+      return true;
+    default:
+      return false;
+  }
+}
+
+bool Parser::is_assign_op(TokenKind op) {
+  switch (op) {
+    case TokenKind::Eq:
+    case TokenKind::PlusEq:
+    case TokenKind::MinusEq:
+    case TokenKind::StarEq:
+    case TokenKind::SlashEq:
+    case TokenKind::PercentEq:
+    case TokenKind::AmpEq:
+    case TokenKind::PipeEq:
+    case TokenKind::CaretEq:
+    case TokenKind::LtLtEq:
+    case TokenKind::GtGtEq:
+      return true;
+    default:
+      return false;
+  }
+}
+
+Parser::Parser(std::vector<Token> tokens, std::string_view source)
+    : m_tokens(std::move(tokens)), m_source(source) {
+  for (const char *name : {
+           "radians",
+           "degrees",
+           "sin",
+           "cos",
+           "tan",
+           "asin",
+           "acos",
+           "atan",
+           "sinh",
+           "cosh",
+           "tanh",
+           "asinh",
+           "acosh",
+           "atanh",
+           "pow",
+           "exp",
+           "log",
+           "exp2",
+           "log2",
+           "sqrt",
+           "inversesqrt",
+           "abs",
+           "sign",
+           "floor",
+           "trunc",
+           "round",
+           "roundEven",
+           "ceil",
+           "fract",
+           "mod",
+           "modf",
+           "min",
+           "max",
+           "clamp",
+           "mix",
+           "step",
+           "smoothstep",
+           "isnan",
+           "isinf",
+           "length",
+           "distance",
+           "dot",
+           "cross",
+           "normalize",
+           "reflect",
+           "refract",
+           "faceforward",
+           "matrixCompMult",
+           "outerProduct",
+           "transpose",
+           "determinant",
+           "inverse",
+           "lessThan",
+           "lessThanEqual",
+           "greaterThan",
+           "greaterThanEqual",
+           "equal",
+           "notEqual",
+           "any",
+           "all",
+           "not",
+           "texture",
+           "texture2D",
+           "texture3D",
+           "textureCube",
+           "textureLod",
+           "texture2DLod",
+           "textureSize",
+           "texelFetch",
+           "texelFetchOffset",
+           "textureOffset",
+           "textureGrad",
+           "textureGather",
+           "imageLoad",
+           "imageStore",
+           "imageSize",
+           "atomicAdd",
+           "atomicMin",
+           "atomicMax",
+           "atomicAnd",
+           "atomicOr",
+           "atomicXor",
+           "atomicExchange",
+           "atomicCompSwap",
+           "dFdx",
+           "dFdy",
+           "fwidth",
+           "emit",
+           "endPrimitive",
+           "barrier",
+           "memoryBarrier",
+           "groupMemoryBarrier",
+           "packUnorm2x16",
+           "packSnorm2x16",
+           "unpackUnorm2x16",
+           "unpackSnorm2x16",
+           "packHalf2x16",
+           "unpackHalf2x16",
+       })
+    m_declared.insert(name);
+}
+
+Program Parser::parse() {
+  Program program;
+
+  program.version = 0;
+
+  if (check(TokenKind::AtVersion)) {
+    advance();
+    Token version = expect(TokenKind::Int, "expected version number");
+    program.version = static_cast<int>(version.int_val);
+    expect(TokenKind::Semicolon, "expected ';'");
+  }
+
+  while (check(TokenKind::AtInclude)) {
+    advance();
+    Token path = expect(TokenKind::String, "expected include path");
+    expect(TokenKind::Semicolon, "expected ';'");
+    program.includes.push_back(path.lexeme);
+  }
+
+  while (!check(TokenKind::EoF)) {
+    size_t pos_before = m_pos;
+
+    // if (check(TokenKind::AtStage)) {
+    //   program.stages.push_back(parse_stage_block());
+    // } else {
+    // }
+
+    NodeID decl = parse_global_decl();
+
+    if (const auto *fn = std::get_if<FuncDecl>(&peek_node_at(decl).data)) {
+      if (fn->stage_kind.has_value()) {
+        program.stages.push_back(decl);
+      } else {
+        program.globals.push_back(decl);
+      }
+    } else {
+      program.globals.push_back(decl);
+    }
+
+    if (m_pos == pos_before) {
+      report_parser_stuck("parse", peek());
+      advance();
+    }
+  }
+  return program;
+}
+
+inline Token Parser::advance() {
+  Token token = m_tokens[m_pos];
+  m_last_token = token;
+
+  if (m_pos + 1 < m_tokens.size()) {
+    ++m_pos;
+  }
+
+  return token;
+}
+
+Token Parser::peek(int offset) const {
+  size_t index = m_pos + static_cast<size_t>(offset);
+
+  if (index >= m_tokens.size()) {
+    return m_tokens.back();
+  }
+
+  return m_tokens[index];
+}
+
+Token Parser::expect(TokenKind kind, std::string_view msg) {
+  if (check(kind)) {
+    return advance();
+  }
+
+  SourceLocation loc = (m_last_token.location.line == 0)
+                           ? peek().location
+                           : SourceLocation{m_last_token.location.line,
+                                            m_last_token.location.col +
+                                                token_src_length(m_last_token),
+                                            m_last_token.location.file};
+  Token token = peek();
+  PUSH_LOCATED_ERROR(m_errors, loc, std::string(msg), m_source);
+
+  return token;
+}
+
+Token Parser::expect_name(std::string_view msg) {
+  Token token = peek();
+
+  bool is_name = token.kind == TokenKind::Identifier ||
+                 (token.kind >= TokenKind::KeywordIn &&
+                  token.kind <= TokenKind::TypeUsampler2D);
+
+  if (is_name) {
+    return advance();
+  }
+
+  SourceLocation location =
+      (m_last_token.location.line == 0)
+          ? token.location
+          : SourceLocation{m_last_token.location.line,
+                           m_last_token.location.col +
+                               token_src_length(m_last_token),
+                           m_last_token.location.file};
+  PUSH_LOCATED_ERROR(m_errors, location, std::string(msg), m_source);
+
+  return token;
+}
+
+inline bool Parser::check(TokenKind kind, int offset) const {
+  return peek(offset).kind == kind;
+}
+
+bool Parser::match(TokenKind kind) {
+  if (!check(kind)) {
+    return false;
+  }
+
+  advance();
+  return true;
+}
+
+NodeID Parser::push_node(ASTNodeData data, SourceLocation location) {
+  NodeID id = static_cast<NodeID>(m_nodes.size());
+  m_nodes.push_back(ASTNode{id, location, TypeRef{TokenKind::KeywordVoid, {}},
+                            std::move(data)});
+  return id;
+}
+
+NodeID Parser::parse_global_decl() {
+  AttributeList attributes = parse_attributes();
+
+  if (check(TokenKind::KeywordStruct)) {
+    return parse_struct_decl();
+  }
+
+  if (check(TokenKind::KeywordConst)) {
+    return parse_const_decl();
+  }
+
+  if (check(TokenKind::KeywordInterface)) {
+    return parse_interface_decl(attributes);
+  }
+
+  if (check(TokenKind::KeywordIn) || check(TokenKind::KeywordOut)) {
+    bool is_in = peek().kind == TokenKind::KeywordIn;
+
+    advance();
+
+    return check(TokenKind::LBrace, 1)
+               ? parse_inline_interface_decl(attributes, is_in)
+               : parse_interface_ref(is_in);
+  }
+
+  if (check(TokenKind::KeywordUniform) || check(TokenKind::KeywordBuffer)) {
+    advance();
+
+    bool is_block = (peek().kind == TokenKind::Identifier ||
+                     (peek().kind >= TokenKind::KeywordIn &&
+                      peek().kind <= TokenKind::TypeUsampler2D)) &&
+                    check(TokenKind::LBrace, 1);
+
+    if (is_block) {
+      --m_pos;
+      return parse_buffer_decl(std::move(attributes),
+                               check(TokenKind::KeywordUniform));
+    } else {
+      --m_pos;
+    }
+
+    return parse_uniform_decl(std::move(attributes));
+  }
+
+  if (check(TokenKind::KeywordFunction)) {
+    return parse_function_decl(std::move(attributes));
+  }
+
+  if (is_type_keyword(peek().kind) || peek().kind == TokenKind::KeywordVoid ||
+      (peek().kind == TokenKind::Identifier &&
+       check(TokenKind::Identifier, 1))) {
+    return parse_var_decl();
+  }
+
+  SourceLocation location = peek().location;
+  PUSH_LOCATED_ERROR(m_errors, location,
+                     "unexpected token in global scope: '" + peek().lexeme +
+                         "'; expected a global declaration",
+                     m_source);
+  synchronize();
+  return push_node(LiteralExpr{int64_t(0)}, location);
+}
+
+// NodeID Parser::parse_stage_block() {
+//   auto stage_token = peek();
+//
+//   SourceLocation location = peek().location;
+//   expect(TokenKind::AtStage, "expected '@stage'");
+//   StageKind kind = StageKind::Vertex;
+//
+//   const std::unordered_map<std::string_view, StageKind> s_alias_stages = {
+//       {"vertex", StageKind::Vertex},
+//       {"fragment", StageKind::Fragment},
+//       {"geometry", StageKind::Geometry},
+//       {"compute", StageKind::Compute}};
+//
+//   auto it = s_alias_stages.find(stage_token.lexeme);
+//   if (it != s_alias_stages.end()) {
+//     kind = it->second;
+//   } else {
+//     switch (peek().kind) {
+//       case TokenKind::KeywordVertex:
+//         advance();
+//         kind = StageKind::Vertex;
+//         break;
+//       case TokenKind::KeywordFragment:
+//         advance();
+//         kind = StageKind::Fragment;
+//         break;
+//       case TokenKind::KeywordGeometry:
+//         advance();
+//         kind = StageKind::Geometry;
+//         break;
+//       case TokenKind::KeywordCompute:
+//         advance();
+//         kind = StageKind::Compute;
+//         break;
+//       default:
+//         m_errors.push_back("expected stage name");
+//     }
+//   }
+//
+//   expect(TokenKind::LBrace, "expected '{'");
+//   std::vector<NodeID> items;
+//   while (!check(TokenKind::RBrace) && !check(TokenKind::EoF)) {
+//     size_t pos_before = m_pos;
+//     items.push_back(parse_stage_item());
+//     if (m_pos == pos_before) {
+//       report_parser_stuck("parse_stage_block", peek());
+//       advance();
+//     }
+//   }
+//   expect(TokenKind::RBrace, "expected '}'");
+//   return push_node(StageBlock{kind, std::move(items)}, location);
+// }
+
+// NodeID Parser::parse_stage_item() {
+//   // Annotations annotations = parse_annotations();
+//   // if (check(TokenKind::KeywordIn) || check(TokenKind::KeywordOut)) {
+//   //   bool is_in = peek().kind == TokenKind::KeywordIn;
+//   //   advance();
+//   //   return check(TokenKind::LBrace, 1) ? parse_interface_block(is_in)
+//   //                                      : parse_interface_ref(is_in);
+//   // }
+//   //
+//   // if (check(TokenKind::KeywordUniform)) {
+//   //   bool is_block = (peek(1).kind == TokenKind::Identifier ||
+//   //                    (peek(1).kind >= TokenKind::KeywordIn &&
+//   //                     peek(1).kind <= TokenKind::TypeUsampler2D)) &&
+//   //                   check(TokenKind::LBrace, 2);
+//   //   if (is_block)
+//   //     return parse_buffer_decl(std::move(annotations), true);
+//   //   return parse_uniform_decl(std::move(annotations));
+//   // }
+//   //
+//   // if (check(TokenKind::KeywordBuffer)) {
+//   //   return parse_buffer_decl(std::move(annotations), false);
+//   // }
+//   //
+//   // if (check(TokenKind::KeywordStruct)) {
+//   //   return parse_struct_decl();
+//   // }
+//   //
+//   // if (check(TokenKind::KeywordConst)) {
+//   //   return parse_const_decl();
+//   // }
+//
+//   return parse_var_decl();
+// }
+
+NodeID Parser::parse_interface_decl(AttributeList attributes) {
+  SourceLocation location = peek().location;
+  expect(TokenKind::KeywordInterface, "expected 'interface'");
+  Token name = expect(TokenKind::Identifier, "expected interface name");
+  InterfaceRole role = InterfaceRole::None;
+
+  validate_exclusive_attributes(m_errors, attributes, "interface declaration",
+                                m_source, AttributeKind::In,
+                                AttributeKind::Uniform);
+
+  for (const auto &attribute : attributes) {
+    switch (attribute.kind) {
+      case AttributeKind::In:
+        role = InterfaceRole::In;
+        break;
+      case AttributeKind::Uniform:
+        role = InterfaceRole::Uniform;
+        break;
+      default:
+        PUSH_INVALID_ATTRIBUTE(m_errors, attribute, "interface declaration",
+                               m_source, AttributeKind::In,
+                               AttributeKind::Uniform);
+        break;
+    }
+  }
+
+  expect(TokenKind::LBrace, "expected '{'");
+
+  std::vector<NodeID> fields;
+
+  while (!check(TokenKind::RBrace) && !check(TokenKind::EoF)) {
+    size_t pos_before = m_pos;
+
+    auto attributes = parse_attributes();
+
+    auto field_id = parse_field_decl(attributes);
+    fields.push_back(field_id);
+
+    if (m_pos == pos_before) {
+      report_parser_stuck("parse_interface_decl", name.lexeme, peek());
+      advance();
+    }
+
+    auto field_decl_node = peek_node_at(field_id);
+
+    if (auto field_decl = std::get_if<FieldDecl>(&field_decl_node.data)) {
+      validate_exclusive_annotations(
+          m_errors, field_decl->annotations, "interface field declaration",
+          m_source, AnnotationKind::Location, AnnotationKind::Uniform);
+
+      switch (role) {
+        case InterfaceRole::In:
+          validate_required_annotations(m_errors, field_decl->annotations,
+                                        field_decl_node.location,
+                                        "interface field declaration", m_source,
+                                        {AnnotationKind::Location});
+
+          validate_allowed_annotations(m_errors, field_decl->annotations,
+                                       "interface field declaration", m_source,
+                                       {AnnotationKind::Location});
+          break;
+        case InterfaceRole::Uniform:
+          // validate_required_annotations(m_errors, field_decl->annotations,
+          //                               field_decl_node.location,
+          //                               "interface field declaration",
+          //                               m_source, {AnnotationKind::Binding});
+
+          validate_allowed_annotations(
+              m_errors, field_decl->annotations, "interface field declaration",
+              m_source, {AnnotationKind::Binding, AnnotationKind::Set});
+          break;
+        case InterfaceRole::None:
+          break;
+      }
+
+      // @TODO: Add validations for empty top-level annotations
+    }
+  }
+
+  expect(TokenKind::RBrace, "expected '}'");
+
+  declare(name.lexeme);
+
+  return push_node(
+      InterfaceDecl{name.lexeme, std::move(fields), role, std::nullopt},
+      location);
+}
+
+NodeID Parser::parse_inline_interface_decl(AttributeList attributes,
+                                           bool is_in) {
+  SourceLocation location = peek().location;
+  Token name = expect(TokenKind::Identifier, "expected inline interface name");
+  expect(TokenKind::LBrace, "expected '{'");
+  std::vector<NodeID> fields;
+
+  InterfaceRole role = InterfaceRole::None;
+
+  validate_exclusive_attributes(m_errors, attributes, "interface declaration",
+                                m_source, AttributeKind::In,
+                                AttributeKind::Uniform);
+
+  Annotations annotations;
+
+  if (!attributes.empty() && is_in) {
+    for (const auto attribute : attributes) {
+      Annotation annotation;
+      annotation.location = attribute.location;
+
+      switch (attribute.kind) {
+        case AttributeKind::Binding: {
+          annotation.kind = AnnotationKind::Binding;
+          if (const auto *value = std::get_if<int32_t>(&attribute.value)) {
+            annotation.slot = *value;
+          }
+          annotations.push_back(annotation);
+          break;
+        }
+        case AttributeKind::Set: {
+          annotation.kind = AnnotationKind::Set;
+          if (const auto *value = std::get_if<int32_t>(&attribute.value)) {
+            annotation.set = *value;
+          }
+          annotations.push_back(annotation);
+          break;
+        }
+        case AttributeKind::Std430: {
+          annotation.kind = AnnotationKind::Std430;
+          annotations.push_back(annotation);
+          break;
+        }
+        case AttributeKind::Std140: {
+          annotation.kind = AnnotationKind::Std140;
+          annotations.push_back(annotation);
+          break;
+        }
+        case AttributeKind::PushConstant: {
+          annotation.kind = AnnotationKind::PushConstant;
+          annotations.push_back(annotation);
+          break;
+        }
+        default:
+          PUSH_INVALID_ATTRIBUTE(
+              m_errors, attribute, "inline interface declaration", m_source,
+              AttributeKind::Binding, AttributeKind::Set, AttributeKind::Std430,
+              AttributeKind::Std140, AttributeKind::PushConstant);
+          break;
+      }
+    }
+  }
+
+  while (!check(TokenKind::RBrace) && !check(TokenKind::EoF)) {
+    size_t pos_before = m_pos;
+
+    auto attributes = parse_attributes();
+
+    fields.push_back(parse_field_decl(attributes));
+
+    if (m_pos == pos_before) {
+      report_parser_stuck("parse_inline_interface_decl", name.lexeme, peek());
+      advance();
+    }
+  }
+
+  expect(TokenKind::RBrace, "expected '}'");
+  std::optional<std::string> instance;
+  if (check(TokenKind::Identifier))
+    instance = advance().lexeme;
+  expect(TokenKind::Semicolon, "expected ';'");
+
+  return push_node(InlineInterfaceDecl{is_in, name.lexeme, std::move(fields),
+                                       instance, annotations},
+                   location);
+}
+
+NodeID Parser::parse_interface_ref(bool is_in) {
+  SourceLocation location = peek().location;
+  Token name = expect(TokenKind::Identifier, "expected interface block name");
+  std::optional<std::string> instance;
+  if (check(TokenKind::Identifier))
+    instance = advance().lexeme;
+  expect(TokenKind::Semicolon, "expected ';'");
+  return push_node(InterfaceRef{is_in, name.lexeme, instance}, location);
+}
+
+NodeID Parser::parse_uniform_decl(AttributeList attributes) {
+  SourceLocation location = peek().location;
+  expect(TokenKind::KeywordUniform, "expected 'uniform'");
+  TypeRef type = parse_type_ref();
+  Token name = expect_name("expected uniform name");
+  std::optional<uint32_t> array_size;
+
+  Annotations annotations;
+
+  for (const auto &attribute : attributes) {
+    Annotation annotation;
+    annotation.location = attribute.location;
+
+    switch (attribute.kind) {
+      case AttributeKind::Binding:
+        annotation.kind = AnnotationKind::Binding;
+        if (const auto *value = std::get_if<int32_t>(&attribute.value)) {
+          annotation.slot = *value;
+        }
+        annotations.push_back(annotation);
+        break;
+      case AttributeKind::Set:
+        annotation.kind = AnnotationKind::Set;
+        if (const auto *value = std::get_if<int32_t>(&attribute.value)) {
+          annotation.set = *value;
+        }
+        annotations.push_back(annotation);
+        break;
+      default:
+        PUSH_INVALID_ATTRIBUTE(m_errors, attribute, "uniform declaration",
+                               m_source, AttributeKind::Binding,
+                               AttributeKind::Set);
+        break;
+    }
+  }
+
+  if (match(TokenKind::LBracket)) {
+    if (check(TokenKind::Int)) {
+      array_size = static_cast<uint32_t>(advance().int_val);
+    }
+    expect(TokenKind::RBracket, "expected ']'");
+  }
+  std::optional<NodeID> default_val;
+
+  if (match(TokenKind::Eq)) {
+    default_val = parse_expr(0);
+  }
+
+  expect(TokenKind::Semicolon, "expected ';'");
+
+  return push_node(UniformDecl{type, name.lexeme, std::move(annotations),
+                               default_val, array_size},
+                   location);
+}
+
+NodeID Parser::parse_buffer_decl(AttributeList attributes, bool is_uniform) {
+  SourceLocation location = peek().location;
+
+  if (is_uniform) {
+    expect(TokenKind::KeywordUniform, "expected 'uniform'");
+  } else {
+    expect(TokenKind::KeywordBuffer, "expected 'buffer'");
+  }
+
+  Token name = expect_name("expected block name");
+
+  Annotations annotations;
+
+  for (const auto &attribute : attributes) {
+    Annotation annotation;
+    annotation.location = attribute.location;
+
+    switch (attribute.kind) {
+      case AttributeKind::Binding:
+        annotation.kind = AnnotationKind::Binding;
+        if (const auto *value = std::get_if<int32_t>(&attribute.value)) {
+          annotation.slot = *value;
+        }
+        annotations.push_back(annotation);
+        break;
+      case AttributeKind::Set:
+        annotation.kind = AnnotationKind::Set;
+        if (const auto *value = std::get_if<int32_t>(&attribute.value)) {
+          annotation.set = *value;
+        }
+        annotations.push_back(annotation);
+        break;
+      case AttributeKind::Location:
+        annotation.kind = AnnotationKind::Location;
+        if (const auto *value = std::get_if<int32_t>(&attribute.value)) {
+          annotation.slot = *value;
+        }
+        annotations.push_back(annotation);
+        break;
+      case AttributeKind::PushConstant:
+        annotation.kind = AnnotationKind::PushConstant;
+        annotations.push_back(annotation);
+        break;
+      default:
+        PUSH_INVALID_ATTRIBUTE(m_errors, attribute, "buffer declaration",
+                               m_source, AttributeKind::Location,
+                               AttributeKind::PushConstant,
+                               AttributeKind::Location, AttributeKind::Binding);
+        break;
+    }
+  }
+
+  expect(TokenKind::LBrace, "expected '{'");
+  std::vector<NodeID> fields;
+
+  while (!check(TokenKind::RBrace) && !check(TokenKind::EoF)) {
+    size_t pos_before = m_pos;
+    fields.push_back(parse_field_decl());
+    if (m_pos == pos_before) {
+      report_parser_stuck("parse_buffer_decl", name.lexeme, peek());
+      advance();
+    }
+  }
+
+  expect(TokenKind::RBrace, "expected '}'");
+  std::optional<std::string> instance_name;
+
+  if (check(TokenKind::Identifier)) {
+    instance_name = advance().lexeme;
+  }
+
+  expect(TokenKind::Semicolon, "expected ';'");
+  return push_node(BufferDecl{name.lexeme, std::move(fields),
+                              std::move(annotations), instance_name,
+                              is_uniform},
+                   location);
+}
+
+NodeID Parser::parse_struct_decl() {
+  SourceLocation location = peek().location;
+  expect(TokenKind::KeywordStruct, "expected 'struct'");
+  Token name = expect(TokenKind::Identifier, "expected struct name");
+  declare(name.lexeme);
+  expect(TokenKind::LBrace, "expected '{'");
+  std::vector<NodeID> fields;
+  while (!check(TokenKind::RBrace) && !check(TokenKind::EoF)) {
+    size_t pos_before = m_pos;
+    fields.push_back(parse_field_decl());
+    if (m_pos == pos_before) {
+      report_parser_stuck("parse_struct_decl", name.lexeme, peek());
+      advance();
+    }
+  }
+  expect(TokenKind::RBrace, "expected '}'");
+  expect(TokenKind::Semicolon, "expected ';'");
+  return push_node(StructDecl{name.lexeme, std::move(fields)}, location);
+}
+
+NodeID Parser::parse_const_decl() {
+  SourceLocation location = peek().location;
+  expect(TokenKind::KeywordConst, "expected 'const'");
+  TypeRef type = parse_type_ref();
+  Token name = expect_name("expected name");
+  expect(TokenKind::Eq, "expected '='");
+  NodeID value_expr = parse_expr(0);
+  expect(TokenKind::Semicolon, "expected ';'");
+  return push_node(VarDecl{type, name.lexeme, value_expr, true}, location);
+}
+
+NodeID Parser::parse_field_decl(std::optional<AttributeList> attributes) {
+  SourceLocation location = peek().location;
+
+  TypeRef type = parse_type_ref();
+  Token name = expect_name("expected field name");
+
+  Annotations annotations;
+
+  if (attributes.has_value()) {
+    validate_exclusive_attributes(m_errors, attributes.value(),
+                                  "field declaration", m_source,
+                                  AttributeKind::In, AttributeKind::Uniform);
+
+    for (const auto &attribute : *attributes) {
+      Annotation annotation;
+      annotation.location = attribute.location;
+
+      switch (attribute.kind) {
+        case AttributeKind::In:
+          annotation.kind = AnnotationKind::In;
+
+          annotations.push_back(annotation);
+          break;
+        case AttributeKind::Location:
+          annotation.kind = AnnotationKind::Location;
+          if (const auto *value = std::get_if<int32_t>(&attribute.value)) {
+            annotation.slot = *value;
+          }
+          annotations.push_back(annotation);
+          break;
+        case AttributeKind::Uniform:
+          annotation.kind = AnnotationKind::Uniform;
+          annotations.push_back(annotation);
+          break;
+        case AttributeKind::Binding:
+          annotation.kind = AnnotationKind::Binding;
+          if (const auto *value = std::get_if<int32_t>(&attribute.value)) {
+            annotation.slot = *value;
+          }
+          annotations.push_back(annotation);
+          break;
+        case AttributeKind::Set:
+          annotation.kind = AnnotationKind::Set;
+          if (const auto *value = std::get_if<int32_t>(&attribute.value)) {
+            annotation.set = *value;
+          }
+          annotations.push_back(annotation);
+          break;
+        default:
+          PUSH_INVALID_ATTRIBUTE(m_errors, attribute, "field declaration",
+                                 m_source, AttributeKind::In,
+                                 AttributeKind::Uniform, AttributeKind::Binding,
+                                 AttributeKind::Set, AttributeKind::Location);
+          break;
+      }
+    }
+  }
+
+  std::optional<uint32_t> array_size;
+
+  if (match(TokenKind::LBracket)) {
+    if (check(TokenKind::Int)) {
+      array_size = static_cast<uint32_t>(advance().int_val);
+    } else {
+      array_size = 0; // unbounded []
+    }
+    expect(TokenKind::RBracket, "expected ']'");
+  }
+
+  std::optional<NodeID> init;
+
+  if (match(TokenKind::Eq)) {
+    init = parse_expr(0);
+  }
+
+  expect(TokenKind::Semicolon, "expected ';'");
+
+  return push_node(FieldDecl{type, name.lexeme, array_size, init, annotations},
+                   location);
+}
+
+AttributeList Parser::parse_attributes() {
+  AttributeList attributes;
+
+  while (true) {
+    auto current_token = peek();
+
+    TokenKind kind = current_token.kind;
+
+    Attribute attribute;
+
+    switch (current_token.kind) {
+      case TokenKind::AtLocation:
+        attribute.kind = AttributeKind::Location;
+        break;
+      case TokenKind::AtBinding:
+        attribute.kind = AttributeKind::Binding;
+        break;
+      case TokenKind::AtSet:
+        attribute.kind = AttributeKind::Set;
+        break;
+      case TokenKind::AtStd430:
+        attribute.kind = AttributeKind::Std430;
+        break;
+      case TokenKind::AtStd140:
+        attribute.kind = AttributeKind::Std140;
+        break;
+      case TokenKind::AtPushConstant:
+        attribute.kind = AttributeKind::PushConstant;
+        break;
+      case TokenKind::AtUniform:
+        attribute.kind = AttributeKind::Uniform;
+        break;
+      case TokenKind::AtIn:
+        attribute.kind = AttributeKind::In;
+        break;
+      case TokenKind::AtVertexStage: {
+        attribute.kind = AttributeKind::VertexStage;
+        break;
+      }
+      case TokenKind::AtGeometryStage: {
+        attribute.kind = AttributeKind::GeometryStage;
+        break;
+      }
+      case TokenKind::AtFragmentStage: {
+        attribute.kind = AttributeKind::FragmentStage;
+        break;
+      }
+      case TokenKind::AtComputeStage: {
+        attribute.kind = AttributeKind::ComputeStage;
+        break;
+      }
+      default: {
+        return attributes;
+      }
+    }
+
+    advance();
+
+    if (match(TokenKind::LParen)) {
+      if (check(TokenKind::Int)) {
+        attribute.value = static_cast<int32_t>(advance().int_val);
+      }
+
+      expect(TokenKind::RParen, "expected ')'");
+    }
+
+    attributes.push_back(attribute);
+  }
+
+  return attributes;
+}
+
+Annotations Parser::parse_annotations() {
+  Annotations annotations;
+
+  const std::unordered_map<std::string_view, StageKind> s_alias_stages = {
+      {"vertex", StageKind::Vertex},
+      {"fragment", StageKind::Fragment},
+      {"geometry", StageKind::Geometry},
+      {"compute", StageKind::Compute}};
+
+  while (true) {
+
+    auto current_token = peek();
+
+    TokenKind kind = current_token.kind;
+
+    auto it = s_alias_stages.find(current_token.lexeme);
+
+    switch (kind) {
+      case TokenKind::AtLocation:
+      case TokenKind::AtBinding:
+      case TokenKind::AtSet:
+      case TokenKind::AtStd430:
+      case TokenKind::AtStd140:
+      case TokenKind::AtPushConstant: {
+        advance();
+        Annotation annotation;
+        annotation.location = current_token.location;
+
+        switch (kind) {
+          case TokenKind::AtLocation:
+            annotation.kind = AnnotationKind::Location;
+            break;
+          case TokenKind::AtBinding:
+            annotation.kind = AnnotationKind::Binding;
+            break;
+          case TokenKind::AtSet:
+            annotation.kind = AnnotationKind::Set;
+            break;
+          case TokenKind::AtStd430:
+            annotation.kind = AnnotationKind::Std430;
+            break;
+          case TokenKind::AtStd140:
+            annotation.kind = AnnotationKind::Std140;
+            break;
+          case TokenKind::AtPushConstant:
+            annotation.kind = AnnotationKind::PushConstant;
+            break;
+          default:
+            break;
+        }
+
+        if (match(TokenKind::LParen)) {
+          if (check(TokenKind::Int))
+            annotation.slot = static_cast<int32_t>(advance().int_val);
+          expect(TokenKind::RParen, "expected ')'");
+        }
+        annotations.push_back(annotation);
+      };
+      default:
+        break;
+    }
+  }
+  return annotations;
+}
+
+TypeRef Parser::parse_type_ref() {
+  Token token = peek();
+
+  if (is_type_keyword(token.kind) || token.kind == TokenKind::KeywordVoid) {
+    advance();
+    return TypeRef{token.kind, {}};
+  }
+  if (token.kind == TokenKind::Identifier) {
+    advance();
+    return TypeRef{TokenKind::Identifier, token.lexeme};
+  }
+  {
+    const auto &loc = token.location;
+    std::string prefix =
+        loc.file.empty()
+            ? (std::to_string(loc.line) + ":" + std::to_string(loc.col) + ": ")
+            : (std::string(loc.file) + ":" + std::to_string(loc.line) + ":" +
+               std::to_string(loc.col) + ": ");
+    std::string err = prefix + "expected type";
+    if (!m_source.empty())
+      err += '\n' + format_source_context(m_source, loc.line, loc.col);
+    m_errors.push_back(std::move(err));
+  }
+  return TypeRef{TokenKind::KeywordVoid, {}};
+}
+
+NodeID Parser::parse_block_stmt() {
+  SourceLocation location = peek().location;
+  expect(TokenKind::LBrace, "expected '{'");
+  std::vector<NodeID> stmts;
+  while (!check(TokenKind::RBrace) && !check(TokenKind::EoF)) {
+    size_t pos_before = m_pos;
+    stmts.push_back(parse_stmt());
+    if (m_pos == pos_before) {
+      report_parser_stuck("parse_block_stmt", peek());
+      advance();
+    }
+  }
+  expect(TokenKind::RBrace, "expected '}'");
+  return push_node(BlockStmt{std::move(stmts)}, location);
+}
+
+NodeID Parser::parse_while_stmt() {
+  SourceLocation location = peek().location;
+  expect(TokenKind::KeywordWhile, "expected 'while'");
+  expect(TokenKind::LParen, "expected '('");
+  NodeID cond = parse_expr(0);
+  expect(TokenKind::RParen, "expected ')'");
+  NodeID body = parse_stmt();
+  return push_node(WhileStmt{cond, body}, location);
+}
+
+NodeID Parser::parse_do_while_stmt() {
+  SourceLocation location = peek().location;
+  expect(TokenKind::KeywordDo, "expected 'do'");
+  NodeID body = parse_stmt();
+  expect(TokenKind::KeywordWhile, "expected 'while'");
+  expect(TokenKind::LParen, "expected '('");
+  NodeID cond = parse_expr(0);
+  expect(TokenKind::RParen, "expected ')'");
+  expect(TokenKind::Semicolon, "expected ';'");
+  return push_node(WhileStmt{cond, body}, location);
+}
+
+NodeID Parser::parse_return_stmt() {
+  SourceLocation location = peek().location;
+  expect(TokenKind::KeywordReturn, "expected 'return'");
+  std::optional<NodeID> value;
+  if (!check(TokenKind::Semicolon))
+    value = parse_expr(0);
+  expect(TokenKind::Semicolon, "expected ';'");
+  return push_node(ReturnStmt{value}, location);
+}
+
+NodeID Parser::parse_local_var_or_expr_stmt() {
+  bool starts_type =
+      is_type_keyword(peek().kind) || peek().kind == TokenKind::KeywordVoid ||
+      (peek().kind == TokenKind::Identifier && check(TokenKind::Identifier, 1));
+
+  if (starts_type) {
+    return parse_var_decl();
+  }
+
+  NodeID expr = parse_expr(0);
+
+  expect(TokenKind::Semicolon, "expected ';'");
+
+  return push_node(ExprStmt{expr}, m_nodes[expr].location);
+}
+
+#undef PRECEDENCE_ASSIGN
+#undef PRECEDENCE_TERNARY
+#undef PRECEDENCE_LOGICAL_OR
+#undef PRECEDENCE_LOGICAL_AND
+#undef PRECEDENCE_BIT_OR
+#undef PRECEDENCE_BIT_XOR
+#undef PRECEDENCE_BIT_AND
+#undef PRECEDENCE_EQUALITY
+#undef PRECEDENCE_RELATIONAL
+#undef PRECEDENCE_SHIFT
+#undef PRECEDENCE_ADDITIVE
+#undef PRECEDENCE_MULT
+#undef PRECEDENCE_UNARY
+#undef PRECEDENCE_POSTFIX
+
+} // namespace astralix

--- a/src/modules/renderer/shader-lang/parser.hpp
+++ b/src/modules/renderer/shader-lang/parser.hpp
@@ -1,0 +1,84 @@
+#pragma once
+#include "shader-lang/ast.hpp"
+#include <optional>
+#include <string_view>
+#include <unordered_set>
+#include <vector>
+
+namespace astralix {
+
+class Parser {
+public:
+  explicit Parser(std::vector<Token> tokens, std::string_view source = "");
+
+  Program parse();
+
+  const std::vector<ASTNode> &nodes() const { return m_nodes; }
+  inline const ASTNode &peek_node_at(NodeID node_id) const {
+    return m_nodes[node_id];
+  }
+  const std::vector<std::string> &errors() const { return m_errors; }
+
+private:
+  NodeID parse_global_decl();
+  // NodeID parse_stage_block();
+  //
+  // NodeID parse_stage_item();
+  NodeID parse_var_decl();
+  NodeID parse_function_decl(AttributeList attributes);
+  NodeID parse_struct_decl();
+  NodeID parse_const_decl();
+  NodeID parse_interface_decl(AttributeList attributes);
+  NodeID parse_inline_interface_decl(AttributeList attributes, bool is_in);
+  NodeID parse_interface_ref(bool is_in);
+  NodeID parse_uniform_decl(AttributeList attributes);
+  NodeID parse_buffer_decl(AttributeList attributes, bool is_uniform = false);
+  NodeID
+  parse_field_decl(std::optional<AttributeList> attributes = std::nullopt);
+  NodeID parse_param();
+  AttributeList parse_attributes();
+  Annotations parse_annotations();
+
+  TypeRef parse_type_ref();
+
+  NodeID parse_stmt();
+  NodeID parse_block_stmt();
+  NodeID parse_if_stmt();
+  NodeID parse_for_stmt();
+  NodeID parse_while_stmt();
+  NodeID parse_do_while_stmt();
+  NodeID parse_return_stmt();
+  NodeID parse_local_var_or_expr_stmt();
+
+  NodeID parse_expr(int min_binding_power = 0);
+  NodeID parse_prefix();
+
+  static int left_binding_power(TokenKind op);
+  static int right_binding_power(TokenKind op);
+  static bool is_assign_op(TokenKind op);
+  static bool is_type_keyword(TokenKind k);
+
+  inline NodeID push_node(ASTNodeData data, SourceLocation loc);
+  Token advance();
+  Token peek(int offset = 0) const;
+  Token expect(TokenKind kind, std::string_view msg);
+  Token expect_name(std::string_view msg);
+  bool check(TokenKind kind, int offset = 0) const;
+  bool match(TokenKind kind);
+  void synchronize();
+
+  void declare(const std::string &name) { m_declared.insert(name); }
+  bool is_declared(const std::string &name) const {
+    return m_declared.count(name) > 0;
+  }
+
+  std::vector<Token> m_tokens;
+  std::string_view m_source;
+  size_t m_pos = 0;
+  Token m_last_token = {};
+  std::vector<ASTNode> m_nodes;
+  std::vector<std::string> m_errors;
+  std::unordered_set<std::string> m_declared;
+};
+
+} // namespace astralix

--- a/src/modules/renderer/shader-lang/token.hpp
+++ b/src/modules/renderer/shader-lang/token.hpp
@@ -1,0 +1,142 @@
+#pragma once
+
+#include <cstdint>
+#include <string>
+#include <string_view>
+namespace astralix {
+
+enum class TokenKind : uint8_t {
+  // Literals
+  Int,
+  Float,
+  Bool,
+  String,
+  // Identifier
+  Identifier,
+  // Decorators
+  AtVertexStage,
+  AtGeometryStage,
+  AtComputeStage,
+  AtFragmentStage,
+  AtVersion,
+  AtInclude,
+  AtDefine,
+  AtLocation,
+  AtBinding,
+  AtSet,
+  AtStd430,
+  AtStd140,
+  AtPushConstant,
+  AtUniform,
+  AtIn,
+  // Keywords
+  KeywordIn,
+  KeywordOut,
+  KeywordInout,
+  KeywordUniform,
+  KeywordBuffer,
+  KeywordStruct,
+  KeywordConst,
+  KeywordVoid,
+  KeywordIf,
+  KeywordElse,
+  KeywordFor,
+  KeywordWhile,
+  KeywordDo,
+  KeywordReturn,
+  KeywordBreak,
+  KeywordContinue,
+  KeywordDiscard,
+  KeywordInterface,
+  KeywordFunction,
+  // Types
+  TypeBool,
+  TypeInt,
+  TypeUint,
+  TypeFloat,
+  TypeVec2,
+  TypeVec3,
+  TypeVec4,
+  TypeIvec2,
+  TypeIvec3,
+  TypeIvec4,
+  TypeUvec2,
+  TypeUvec3,
+  TypeUvec4,
+  TypeMat2,
+  TypeMat3,
+  TypeMat4,
+  TypeSampler2D,
+  TypeSamplerCube,
+  TypeSampler2DShadow,
+  TypeIsampler2D,
+  TypeUsampler2D,
+  // Punctuation
+  LBrace,
+  RBrace,
+  LParen,
+  RParen,
+  LBracket,
+  RBracket,
+  Semicolon,
+  Comma,
+  Dot,
+  // Operators
+  Plus,
+  Minus,
+  Arrow,
+  Star,
+  Slash,
+  Percent,
+  Eq,
+  EqEq,
+  Bang,
+  BangEq,
+  Lt,
+  Gt,
+  LtEq,
+  GtEq,
+  AmpAmp,
+  PipePipe,
+  Amp,
+  Pipe,
+  Caret,
+  Tilde,
+  LtLt,
+  GtGt,
+  PlusEq,
+  MinusEq,
+  StarEq,
+  SlashEq,
+  PercentEq,
+  AmpEq,
+  PipeEq,
+  CaretEq,
+  LtLtEq,
+  GtGtEq,
+  PlusPlus,
+  MinusMinus,
+  Question,
+  Colon,
+  // Special
+  EoF,
+  Error,
+};
+
+struct SourceLocation {
+  uint32_t line, col;
+  std::string_view file;
+};
+
+struct Token {
+  TokenKind kind = TokenKind::Error;
+  SourceLocation location = {};
+  std::string lexeme;
+  union {
+    int64_t int_val = 0;
+    double float_val;
+    bool bool_val;
+  };
+};
+
+} // namespace astralix

--- a/src/modules/renderer/shader-lang/tokenizer.cpp
+++ b/src/modules/renderer/shader-lang/tokenizer.cpp
@@ -1,0 +1,442 @@
+#include "shader-lang/tokenizer.hpp"
+#include "shader-lang/token.hpp"
+#include <string_view>
+#include <unordered_map>
+
+namespace astralix {
+const std::unordered_map<std::string_view, TokenKind> Tokenizer::s_keywords = {
+    {"in", TokenKind::KeywordIn},
+    {"out", TokenKind::KeywordOut},
+    {"inout", TokenKind::KeywordInout},
+    {"uniform", TokenKind::KeywordUniform},
+    {"buffer", TokenKind::KeywordBuffer},
+    {"struct", TokenKind::KeywordStruct},
+    {"const", TokenKind::KeywordConst},
+    {"void", TokenKind::KeywordVoid},
+    {"fn", TokenKind::KeywordFunction},
+    {"if", TokenKind::KeywordIf},
+    {"else", TokenKind::KeywordElse},
+    {"for", TokenKind::KeywordFor},
+    {"while", TokenKind::KeywordWhile},
+    {"do", TokenKind::KeywordDo},
+    {"return", TokenKind::KeywordReturn},
+    {"break", TokenKind::KeywordBreak},
+    {"continue", TokenKind::KeywordContinue},
+    {"discard", TokenKind::KeywordDiscard},
+    {"interface", TokenKind::KeywordInterface},
+    {"true", TokenKind::Bool},
+    {"false", TokenKind::Bool},
+    {"bool", TokenKind::TypeBool},
+    {"int", TokenKind::TypeInt},
+    {"uint", TokenKind::TypeUint},
+    {"float", TokenKind::TypeFloat},
+    {"vec2", TokenKind::TypeVec2},
+    {"vec3", TokenKind::TypeVec3},
+    {"vec4", TokenKind::TypeVec4},
+    {"ivec2", TokenKind::TypeIvec2},
+    {"ivec3", TokenKind::TypeIvec3},
+    {"ivec4", TokenKind::TypeIvec4},
+    {"uvec2", TokenKind::TypeUvec2},
+    {"uvec3", TokenKind::TypeUvec3},
+    {"uvec4", TokenKind::TypeUvec4},
+    {"mat2", TokenKind::TypeMat2},
+    {"mat3", TokenKind::TypeMat3},
+    {"mat4", TokenKind::TypeMat4},
+    {"sampler2D", TokenKind::TypeSampler2D},
+    {"samplerCube", TokenKind::TypeSamplerCube},
+    {"sampler2DShadow", TokenKind::TypeSampler2DShadow},
+    {"isampler2D", TokenKind::TypeIsampler2D},
+    {"usampler2D", TokenKind::TypeUsampler2D},
+};
+
+const std::unordered_map<std::string_view, TokenKind> Tokenizer::s_decorators =
+    {
+        {"vertex", TokenKind::AtVertexStage},
+        {"fragment", TokenKind::AtFragmentStage},
+        {"compute", TokenKind::AtComputeStage},
+        {"geometry", TokenKind::AtGeometryStage},
+        {"version", TokenKind::AtVersion},
+        {"include", TokenKind::AtInclude},
+        {"define", TokenKind::AtDefine},
+        {"location", TokenKind::AtLocation},
+        {"binding", TokenKind::AtBinding},
+        {"set", TokenKind::AtSet},
+        {"std430", TokenKind::AtStd430},
+        {"std140", TokenKind::AtStd140},
+        {"push_constant", TokenKind::AtPushConstant},
+        {"in", TokenKind::AtIn},
+        {"uniform", TokenKind::AtUniform},
+};
+
+Token Tokenizer::next() {
+  if (m_peeked) {
+    Token token = *m_peeked;
+    m_peeked.reset();
+    return token;
+  }
+
+  return scan_token();
+}
+
+Token Tokenizer::peek() {
+  if (!m_peeked) {
+    m_peeked = scan_token();
+  }
+
+  return *m_peeked;
+}
+
+Token Tokenizer::scan_token() {
+  skip_whitespace_and_comments();
+  m_token_start_col = m_col;
+
+  if (m_pos >= m_source.size()) {
+    return make_token(TokenKind::EoF);
+  }
+
+  char character = current();
+
+  if (character == '@') {
+    return scan_decorator();
+  }
+
+  if (character == '"') {
+    return scan_string();
+  }
+
+  if (std::isdigit(character)) {
+    return scan_number();
+  }
+
+  if (std::isalpha(character) || character == '_') {
+    return scan_identifier_or_keyword();
+  }
+
+  return scan_operator();
+}
+
+void Tokenizer::skip_whitespace_and_comments() {
+  while (m_pos < m_source.size()) {
+    char character = current();
+
+    if (character == '\n') {
+      ++m_line;
+      m_col = 1;
+      ++m_pos;
+      continue;
+    }
+
+    if (std::isspace(character)) {
+      advance();
+      continue;
+    }
+
+    if (character == '/' && lookahead() == '/') {
+      while (m_pos < m_source.size() && current() != '\n')
+        ++m_pos;
+      continue;
+    }
+
+    if (character == '/' && lookahead() == '*') {
+      advance();
+      advance();
+
+      while (m_pos + 1 < m_source.size() &&
+             !(current() == '*' && lookahead() == '/')) {
+        if (current() == '\n') {
+          ++m_line;
+          m_col = 1;
+          ++m_pos;
+        } else {
+          advance();
+        }
+      }
+
+      advance();
+      advance();
+      continue;
+    }
+    break;
+  }
+}
+
+Tokenizer::Tokenizer(std::string_view source, std::string_view filename)
+    : m_source(source), m_filename(filename) {}
+
+char Tokenizer::current() const {
+  if (m_pos >= m_source.size()) {
+    return '\0';
+  }
+
+  return m_source[m_pos];
+}
+
+inline char Tokenizer::lookahead(int offset) const {
+  size_t index = m_pos + static_cast<size_t>(offset);
+
+  if (index >= m_source.size()) {
+    return '\0';
+  }
+
+  return m_source[index];
+}
+
+inline char Tokenizer::advance() {
+  char c = m_source[m_pos++];
+  ++m_col;
+  return c;
+}
+
+inline bool Tokenizer::match(char expected) {
+  if (current() != expected) {
+    return false;
+  }
+
+  ++m_pos;
+  return true;
+}
+
+inline Token Tokenizer::make_token(TokenKind kind, std::string lexeme) const {
+  Token token;
+
+  token.kind = kind;
+  token.location = {m_line, m_token_start_col, m_filename};
+  token.lexeme = std::move(lexeme);
+
+  return token;
+}
+
+Token Tokenizer::error_token(std::string_view msg) {
+  m_errors.emplace_back(msg);
+  return make_token(TokenKind::Error, std::string(msg));
+}
+
+Token Tokenizer::scan_decorator() {
+  advance();
+
+  size_t start = m_pos;
+
+  while (std::isalnum(current()) || current() == '_') {
+    advance();
+  }
+
+  std::string_view name = m_source.substr(start, m_pos - start);
+
+  auto it = s_decorators.find(name);
+
+  if (it == s_decorators.end()) {
+    return error_token("unknown decorator '@" + std::string(name) + "'");
+  }
+
+  return make_token(it->second, std::string(name));
+}
+
+Token Tokenizer::scan_number() {
+  size_t start = m_pos;
+
+  bool is_hex = (current() == '0' && lookahead() == 'x');
+
+  if (is_hex) {
+    advance();
+    advance();
+  }
+
+  while (std::isxdigit(current())) {
+    advance();
+  }
+
+  bool is_float = !is_hex && current() == '.' && !std::isalpha(lookahead()) &&
+                  lookahead() != '_';
+
+  if (is_float) {
+    advance();
+    while (std::isdigit(current()))
+      advance();
+  }
+
+  bool has_float_suffix = !is_hex && current() == 'f';
+  bool has_unasigned_suffix = !is_float && !is_hex && current() == 'u';
+
+  if (has_float_suffix || has_unasigned_suffix) {
+    advance();
+  }
+
+  std::string raw(m_source.substr(start, m_pos - start));
+
+  Token token = make_token(
+      is_float || has_float_suffix ? TokenKind::Float : TokenKind::Int, raw);
+
+  if (is_float || has_float_suffix) {
+    token.float_val = std::stod(raw);
+  } else if (is_hex) {
+    token.int_val = std::stoll(raw, nullptr, 0);
+  } else {
+    token.int_val = std::stoll(raw);
+  }
+
+  return token;
+}
+
+Token Tokenizer::scan_string() {
+  advance();
+
+  size_t start = m_pos;
+
+  while (m_pos < m_source.size() && current() != '"' && current() != '\n') {
+    advance();
+  }
+
+  if (current() != '"') {
+    return error_token("unterminated string literal");
+  }
+
+  std::string value(m_source.substr(start, m_pos - start));
+
+  advance();
+
+  return make_token(TokenKind::String, std::move(value));
+}
+
+Token Tokenizer::scan_identifier_or_keyword() {
+  size_t start = m_pos;
+
+  while (std::isalnum(current()) || current() == '_') {
+    advance();
+  }
+
+  std::string_view text = m_source.substr(start, m_pos - start);
+  auto it = s_keywords.find(text);
+
+  if (it == s_keywords.end()) {
+    return make_token(TokenKind::Identifier, std::string(text));
+  }
+
+  Token token = make_token(it->second, std::string(text));
+
+  if (it->second == TokenKind::Bool) {
+    token.bool_val = (text == "true");
+  }
+
+  return token;
+}
+
+Token Tokenizer::scan_operator() {
+  char character = advance();
+  switch (character) {
+    case '{':
+      return make_token(TokenKind::LBrace);
+    case '}':
+      return make_token(TokenKind::RBrace);
+    case '(':
+      return make_token(TokenKind::LParen);
+    case ')':
+      return make_token(TokenKind::RParen);
+    case '[':
+      return make_token(TokenKind::LBracket);
+    case ']':
+      return make_token(TokenKind::RBracket);
+    case ';':
+      return make_token(TokenKind::Semicolon);
+    case ',':
+      return make_token(TokenKind::Comma);
+    case '.':
+      return make_token(TokenKind::Dot);
+    case '?':
+      return make_token(TokenKind::Question);
+    case ':':
+      return make_token(TokenKind::Colon);
+    case '~':
+      return make_token(TokenKind::Tilde);
+    case '+': {
+      if (match('+')) {
+        return make_token(TokenKind::PlusPlus);
+      }
+
+      if (match('=')) {
+        return make_token(TokenKind::PlusEq);
+      }
+
+      return make_token(TokenKind::Plus);
+    }
+    case '-': {
+      if (match('>')) {
+        return make_token(TokenKind::Arrow);
+      }
+
+      if (match('-')) {
+        return make_token(TokenKind::MinusMinus);
+      }
+
+      if (match('=')) {
+        return make_token(TokenKind::MinusEq);
+      }
+
+      return make_token(TokenKind::Minus);
+    }
+    case '*': {
+      return match('=') ? make_token(TokenKind::StarEq)
+                        : make_token(TokenKind::Star);
+    }
+    case '/': {
+      return match('=') ? make_token(TokenKind::SlashEq)
+                        : make_token(TokenKind::Slash);
+    }
+    case '%': {
+      return match('=') ? make_token(TokenKind::PercentEq)
+                        : make_token(TokenKind::Percent);
+    }
+    case '=': {
+      return match('=') ? make_token(TokenKind::EqEq)
+                        : make_token(TokenKind::Eq);
+    }
+    case '!': {
+      return match('=') ? make_token(TokenKind::BangEq)
+                        : make_token(TokenKind::Bang);
+    }
+    case '<': {
+      if (match('<')) {
+        return match('=') ? make_token(TokenKind::LtLtEq)
+                          : make_token(TokenKind::LtLt);
+      }
+
+      return match('=') ? make_token(TokenKind::LtEq)
+                        : make_token(TokenKind::Lt);
+    }
+    case '>': {
+      if (match('>')) {
+        return match('=') ? make_token(TokenKind::GtGtEq)
+                          : make_token(TokenKind::GtGt);
+      }
+
+      return match('=') ? make_token(TokenKind::GtEq)
+                        : make_token(TokenKind::Gt);
+    }
+    case '&': {
+      if (match('&')) {
+        return make_token(TokenKind::AmpAmp);
+      }
+
+      return match('=') ? make_token(TokenKind::AmpEq)
+                        : make_token(TokenKind::Amp);
+    }
+    case '|': {
+      if (match('|')) {
+        return make_token(TokenKind::PipePipe);
+      }
+
+      return match('=') ? make_token(TokenKind::PipeEq)
+                        : make_token(TokenKind::Pipe);
+    }
+
+    case '^': {
+      return match('=') ? make_token(TokenKind::CaretEq)
+                        : make_token(TokenKind::Caret);
+    }
+
+    default:
+      return error_token(std::string("unexpected character '") + character +
+                         "'");
+  }
+}
+
+} // namespace astralix

--- a/src/modules/renderer/shader-lang/tokenizer.hpp
+++ b/src/modules/renderer/shader-lang/tokenizer.hpp
@@ -1,0 +1,48 @@
+#pragma once
+
+#include "shader-lang/token.hpp"
+#include <optional>
+#include <unordered_map>
+#include <vector>
+
+namespace astralix {
+class Tokenizer {
+public:
+  explicit Tokenizer(std::string_view source, std::string_view filename = "");
+
+  Token next();
+  Token peek();
+
+  const std::vector<std::string> &errors() const { return m_errors; }
+
+private:
+  Token scan_token();
+  Token scan_decorator();
+  Token scan_number();
+  Token scan_string();
+  Token scan_identifier_or_keyword();
+  Token scan_operator();
+
+  void skip_whitespace_and_comments();
+  char current() const;
+  char lookahead(int offset = 1) const;
+  char advance();
+  bool match(char expected);
+
+  Token make_token(TokenKind kind, std::string lexeme = {}) const;
+  Token error_token(std::string_view msg);
+
+  std::string_view m_source;
+  std::string_view m_filename;
+  size_t m_pos = 0;
+  uint32_t m_line = 1;
+  uint32_t m_col = 1;
+  uint32_t m_token_start_col = 1;
+  std::optional<Token> m_peeked;
+  std::vector<std::string> m_errors;
+
+  static const std::unordered_map<std::string_view, TokenKind> s_keywords;
+  static const std::unordered_map<std::string_view, TokenKind> s_decorators;
+};
+
+} // namespace astralix

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,0 +1,39 @@
+cmake_minimum_required(VERSION 3.21)
+project(astralix_tests CXX)
+
+set(CMAKE_CXX_STANDARD 20)
+
+set(VCPKG_INSTALLED_ROOT "${CMAKE_SOURCE_DIR}/../vcpkg_installed/x64-linux")
+
+set(GTest_DIR "${VCPKG_INSTALLED_ROOT}/share/gtest")
+find_package(GTest CONFIG REQUIRED)
+
+set(SHADER_LANG_DIR "${CMAKE_SOURCE_DIR}/../src/modules/renderer/shader-lang")
+set(AXSLC_DIR "${CMAKE_SOURCE_DIR}/../axslc")
+
+file(GLOB_RECURSE SHADER_LANG_SRC
+  "${SHADER_LANG_DIR}/*.cpp"
+  "${SHADER_LANG_DIR}/emitters/*.cpp")
+list(FILTER SHADER_LANG_SRC EXCLUDE REGEX "\\.test\\.cpp$")
+
+file(GLOB_RECURSE TEST_SRC
+  "${CMAKE_SOURCE_DIR}/../src/modules/renderer/shader-lang/*.test.cpp"
+  "${AXSLC_DIR}/*.test.cpp")
+
+add_executable(astralix_tests
+  main.cpp
+  ${TEST_SRC}
+  ${SHADER_LANG_SRC}
+  "${AXSLC_DIR}/args.cpp")
+
+target_include_directories(astralix_tests PRIVATE
+  "${CMAKE_SOURCE_DIR}/../src/modules/renderer"
+  "${AXSLC_DIR}")
+
+target_link_libraries(astralix_tests PRIVATE
+  GTest::gtest
+  GTest::gtest_main)
+
+include(GoogleTest)
+enable_testing()
+gtest_discover_tests(astralix_tests)

--- a/tests/main.cpp
+++ b/tests/main.cpp
@@ -1,16 +1,85 @@
+#include <cstdio>
 #include <gtest/gtest.h>
+
+#define C_RESET "\033[0m"
+#define C_BOLD "\033[1m"
+#define C_DIM "\033[2m"
+#define C_GREEN "\033[32m"
+#define C_RED "\033[31m"
+#define C_GRAY "\033[90m"
+#define C_CYAN "\033[36m"
+
+class PrettyPrinter : public testing::EmptyTestEventListener {
+public:
+  void OnTestSuiteStart(const testing::TestSuite &suite) override {
+    std::printf("\n" C_BOLD C_CYAN "  %s" C_RESET "\n", suite.name());
+  }
+
+  void OnTestSuiteEnd(const testing::TestSuite &suite) override {
+    int passed = suite.successful_test_count();
+    int failed = suite.failed_test_count();
+    int total = suite.total_test_count();
+
+    if (failed == 0) {
+      std::printf(C_GRAY "    %d/%d passed" C_RESET "\n", passed, total);
+    } else {
+      std::printf(C_RED "    %d failed, %d passed, %d total" C_RESET "\n",
+                  failed, passed, total);
+    }
+  }
+
+  void OnTestStart(const testing::TestInfo &info) override {
+    std::printf(C_DIM "    ○ %s" C_RESET, info.name());
+    std::fflush(stdout);
+  }
+
+  void OnTestPartResult(const testing::TestPartResult &result) override {
+    if (result.failed()) {
+      std::printf("\n" C_RED "      ✕ %s" C_RESET C_DIM " (%s:%d)" C_RESET
+                  "\n" C_RED "        %s" C_RESET "\n",
+                  result.summary(),
+                  result.file_name() ? result.file_name() : "?",
+                  result.line_number(), result.message());
+    }
+  }
+
+  void OnTestEnd(const testing::TestInfo &info) override {
+    const char *status = info.result()->Passed() ? C_GREEN "✓" : C_RED "✕";
+    std::printf("\r    %s" C_RESET " %s" C_DIM " (%.0f ms)" C_RESET "\n",
+                status, info.name(), info.result()->elapsed_time() * 1.0);
+  }
+
+  void OnTestProgramEnd(const testing::UnitTest &unit) override {
+    int passed = unit.successful_test_count();
+    int failed = unit.failed_test_count();
+    int total = unit.total_test_count();
+    int ms = static_cast<int>(unit.elapsed_time());
+
+    std::printf("\n" C_BOLD);
+    if (failed == 0) {
+      std::printf(C_GREEN "  Tests:  %d passed, %d total" C_RESET "\n", passed,
+                  total);
+    } else {
+      std::printf(C_RED "  Tests:  %d failed" C_RESET ", %d passed, %d total\n",
+                  failed, passed, total);
+    }
+    std::printf(C_GRAY "  Time:   %d ms" C_RESET "\n\n", ms);
+  }
+};
 
 #define REPEAT 1
 
 int main(int argc, char **argv) {
   testing::InitGoogleTest(&argc, argv);
 
+  auto &listeners = testing::UnitTest::GetInstance()->listeners();
+  delete listeners.Release(listeners.default_result_printer());
+  listeners.Append(new PrettyPrinter);
+
   for (int i = 0; i < REPEAT; i++) {
     int result = RUN_ALL_TESTS();
-
-    if (result != 0) {
+    if (result != 0)
       return result;
-    }
   }
 
   return 0;


### PR DESCRIPTION
## Main Changes
- Full AXSL shader language compiler pipeline: tokenizer, Pratt parser, AST linker, GLSL emitter, and standalone CLI

Shaders are now authored in AXSL (Astralix Shader Language), a custom language that compiles to GLSL. 

The pipeline is structured as discrete stages: 
- tokenization
- parsing
- linking
- and emission, each with independent error accumulation. 

The OpenGL shader backend integrates the compiler transparently, with an mtime-based cache to skip recompilation on unchanged sources.

### Key Features Added

- **Core compiler pipeline** (`Tokenizer`, `Parser`, `Linker`, `Compiler`, `OpenGLGLSLEmitter`)
  - Pratt parsing for expressions, recursive-descent for statements and declarations
  - Deferred include resolution and symbol resolution at link time
  - Interface flattening and reachability culling at emission time

- **Standalone CLI** (`axslc`)
  - Compiles `.axsl` files to per-stage `.vert.glsl` / `.frag.glsl` output
  - Supports `-o` output directory, `-I` include path, `-v` verbose mode

- **AXSL shader assets**
  - `light.axsl` - PBR-adjacent lighting with TBN, parallax occlusion mapping, directional + point lights, and dual-output bloom split
  - `skybox.axsl` - Cubemap skybox with depth trick (`pos.xyww`)
  - `hdr.axsl` - HDR tonemapping with exposure and gamma correction
  - `helpers/` - Shared lighting, PCF shadow mapping, and convolution kernel utilities

- **End-to-end compiler tests** (`compiler.test.cpp`)
  - ~86 tests across `ShaderCompiler` and `ShaderDiagnostics` suites
  - Covers emission correctness, dead code elimination, interface flattening, output accumulator semantics, symbol resolution, and diagnostic formatting

### Minor cleanups
- `compile()` refactored into `compile_glsl(source, type)` to separate source loading from GL compilation
- Removed path from GLSL compile error (now surfaced through AXSL diagnostics)

### Preview

Pipeline overview:

```mermaid
flowchart TD
    source([".axsl source"])

    subgraph pipeline["Compiler Pipeline"]
        tokenizer["Tokenizer<br/>tokens + errors"]
        parser["Parser<br/>Pratt expressions<br/>recursive-descent stmts<br/>AST + UnresolvedRefs"]
        linker["Linker<br/>include resolution<br/>symbol resolution<br/>uniform usage tracking"]
        emitter["GLSL Emitter<br/>interface flattening<br/>reachability culling<br/>per-stage emission"]
    end

    cache[("mtime cache<br/>.vert.glsl / .frag.glsl")]

    vertex["vertex GLSL"]
    fragment["fragment GLSL"]

    subgraph consumers["Consumers"]
        axslc["axslc CLI"]
        opengl["OpenGLShader"]
    end

    source --> tokenizer --> parser --> linker --> emitter
    emitter --> vertex & fragment
    vertex & fragment <--> cache
    vertex & fragment --> axslc
    vertex & fragment --> opengl
```