### PR TITLE
Add ECS system lifecycle, job system, granular profiling, and exception metadata

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,7 +63,7 @@ jobs:
             core.exportVariable('ACTIONS_RUNTIME_TOKEN', process.env.ACTIONS_RUNTIME_TOKEN || '');
 
       - name: Install vcpkg packages
-        run: ./vcpkg/vcpkg install --triplet x64-linux --x-install-root="${VCPKG_INSTALL_ROOT}"
+        run: ./vcpkg/vcpkg install --triplet x64-linux --x-feature=dev --x-install-root="${VCPKG_INSTALL_ROOT}"
 
       - name: Configure
         run: cmake --preset=debug -DASTRALIX_STREAMS_FORMATS=Json -DVCPKG_MANIFEST_INSTALL=OFF

--- a/.gitmodules
+++ b/.gitmodules
@@ -2,10 +2,6 @@
 	path = external/PhysX
 	url = https://github.com/NVIDIA-Omniverse/PhysX
   branch = main
-[submodule "external/faker-cxx"]
-	path = external/faker-cxx
-	url = https://github.com/cieslarmichal/faker-cxx
-	branch = main
 [submodule "external/imgui"]
 	path = external/imgui
 	url = https://github.com/LuizPedroSousa/imgui

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -194,6 +194,7 @@ add_subdirectory(src/shared/containers)
 if(NOT ASTRA_ENABLE_TESTS)
   add_subdirectory(src/shared/events)
   add_subdirectory(src/shared/ecs)
+  add_subdirectory(src/modules/jobs)
   add_subdirectory(src/modules/streams)
   add_subdirectory(src/modules/renderer/shader-lang)
   add_subdirectory(src/modules/project)
@@ -399,6 +400,7 @@ if(NOT ASTRA_ENABLE_TESTS)
           events
           ecs
           streams
+          jobs
           project
           window
           shader-lang

--- a/src/modules/application/CMakeLists.txt
+++ b/src/modules/application/CMakeLists.txt
@@ -2,6 +2,9 @@
 file(GLOB_RECURSE APPLICATION_SRC ${CMAKE_CURRENT_SOURCE_DIR}/*.cpp)
 file(GLOB_RECURSE APPLICATION_HEADER ${CMAKE_CURRENT_SOURCE_DIR}/*.hpp)
 
+list(FILTER APPLICATION_SRC EXCLUDE REGEX ".*\\.test\\.cpp$")
+list(FILTER APPLICATION_HEADER EXCLUDE REGEX ".*\\.test\\.hpp$")
+
 add_library(application STATIC ${APPLICATION_SRC} ${APPLICATION_HEADER})
 
 include_directories(${CMAKE_SOURCE_DIR}/external)
@@ -17,7 +20,17 @@ target_link_libraries(
   PUBLIC
   glad::glad
   project
+  jobs
   engine window shared::foundation
 )
+
+if(ASTRA_RENDERER_HOT_RELOAD)
+  target_compile_definitions(application PRIVATE
+    ASTRA_RENDERER_HOT_RELOAD
+    ASTRA_RENDER_PASSES_MODULE_PATH="${CMAKE_BINARY_DIR}/hotreload/librender_passes_live.so"
+    ASTRA_RENDER_PASSES_SOURCE_DIR="${PROJECT_SOURCE_DIR}/src/modules/renderer"
+    ASTRA_RENDER_PASSES_BUILD_DIR="${CMAKE_BINARY_DIR}"
+  )
+endif()
 
 source_group(TREE "${CMAKE_CURRENT_SOURCE_DIR}" FILES ${APPLICATION_SOURCES} ${APPLICATION_HEADERS})

--- a/src/modules/application/application.cpp
+++ b/src/modules/application/application.cpp
@@ -7,25 +7,62 @@
 #include "managers/project-manager.hpp"
 #include "managers/system-manager.hpp"
 #include "managers/window-manager.hpp"
+#include "systems/job-system/job-system.hpp"
 #include "time.hpp"
 #include "trace.hpp"
+#if defined(ASTRA_RENDERER_HOT_RELOAD)
+#include "module-handle.hpp"
+#include "systems/render-system/render-system.hpp"
+#endif
 
 namespace astralix {
+
+namespace {
+
+constexpr size_t k_main_thread_job_drain_budget = 2u;
+
+} // namespace
+
 Application *Application::m_instance = nullptr;
 
 Application *Application::init() {
   ASTRA_PROFILE_N("Application::init");
   m_instance = new Application;
 
-  EventDispatcher::init();
-  EventScheduler::init();
-  Time::init();
-  ConsoleManager::get();
-  ProjectManager::init();
-  Engine::init();
-  SystemManager::init();
-  WindowManager::init();
+  {
+    ASTRA_PROFILE_N("EventDispatcher::init");
+    EventDispatcher::init();
+  }
+  {
+    ASTRA_PROFILE_N("EventScheduler::init");
+    EventScheduler::init();
+  }
+  {
+    ASTRA_PROFILE_N("Time::init");
+    Time::init();
+  }
+  {
+    ASTRA_PROFILE_N("ConsoleManager::init");
+    ConsoleManager::get();
+  }
+  {
+    ASTRA_PROFILE_N("ProjectManager::init");
+    ProjectManager::init();
+  }
+  {
+    ASTRA_PROFILE_N("Engine::init");
+    Engine::init();
+  }
+  {
+    ASTRA_PROFILE_N("SystemManager::init");
+    SystemManager::init();
+  }
+  {
+    ASTRA_PROFILE_N("WindowManager::init");
+    WindowManager::init();
+  }
   if (ApplicationPluginRegistry::get() == nullptr) {
+    ASTRA_PROFILE_N("ApplicationPluginRegistry::init");
     ApplicationPluginRegistry::init();
   }
 
@@ -34,16 +71,28 @@ Application *Application::init() {
 
 void Application::start() {
   ASTRA_PROFILE_N("Application::start");
-  WindowManager::get()->start();
-  Engine::get()->start();
+  {
+    ASTRA_PROFILE_N("WindowManager::start");
+    WindowManager::get()->start();
+  }
+  {
+    ASTRA_PROFILE_N("Engine::start");
+    Engine::get()->start();
+  }
 
-  ApplicationPluginContext plugin_context{
-      .project = active_project(),
-      .systems = SystemManager::get(),
-  };
-  application_plugin_registry()->apply_plugins(plugin_context);
+  {
+    ASTRA_PROFILE_N("ApplicationPluginRegistry::apply_plugins");
+    ApplicationPluginContext plugin_context{
+        .project = active_project(),
+        .systems = SystemManager::get(),
+    };
+    application_plugin_registry()->apply_plugins(plugin_context);
+  }
 
-  SystemManager::get()->start();
+  {
+    ASTRA_PROFILE_N("SystemManager::start");
+    SystemManager::get()->start();
+  }
 }
 
 void Application::run() {
@@ -54,7 +103,38 @@ void Application::run() {
 
   auto scheduler = EventScheduler::get();
 
+#if defined(ASTRA_RENDERER_HOT_RELOAD)
+  ModuleHandle render_passes_module(ModuleHandle::Config{
+      .module_path = ASTRA_RENDER_PASSES_MODULE_PATH,
+      .source_dir = ASTRA_RENDER_PASSES_SOURCE_DIR,
+      .build_dir = ASTRA_RENDER_PASSES_BUILD_DIR,
+      .build_target = "render_passes_live",
+  });
+  {
+    ASTRA_PROFILE_N("RenderPassesLoader::initial_load");
+    if (render_passes_module.load()) {
+      auto *render_system = SystemManager::get()->get_system<RenderSystem>();
+      if (render_system != nullptr) {
+        render_system->load_passes_from_module(render_passes_module.api());
+      }
+    }
+  }
+#endif
+
   while (wm->is_open()) {
+    if (m_pre_frame_callback) m_pre_frame_callback();
+#if defined(ASTRA_RENDERER_HOT_RELOAD)
+    if (render_passes_module.poll_changed()) {
+      auto *render_system = system->get_system<RenderSystem>();
+      if (render_system != nullptr) {
+        render_system->prepare_for_pass_reload();
+      }
+      render_passes_module.api()->unload();
+      if (render_passes_module.load() && render_system != nullptr) {
+        render_system->load_passes_from_module(render_passes_module.api());
+      }
+    }
+#endif
     ASTRA_FRAME_MARK;
     ASTRA_PROFILE_N("Application::frame");
     time->update();
@@ -66,8 +146,20 @@ void Application::run() {
       ASTRA_PROFILE_N("EventScheduler::POST_FRAME");
       scheduler->bind(SchedulerType::POST_FRAME);
     }
+    {
+      ASTRA_PROFILE_N("JobSystem::drain_main_queue_pre_update");
+      if (auto *jobs = JobSystem::get(); jobs != nullptr) {
+        jobs->drain_main_queue(k_main_thread_job_drain_budget);
+      }
+    }
     system->fixed_update(1 / 60.0f);
     system->update(Time::get()->get_deltatime());
+    {
+      ASTRA_PROFILE_N("JobSystem::drain_main_queue_post_update");
+      if (auto *jobs = JobSystem::get(); jobs != nullptr) {
+        jobs->drain_main_queue(k_main_thread_job_drain_budget);
+      }
+    }
     {
       ASTRA_PROFILE_N("EventScheduler::IMMEDIATE");
       scheduler->bind(SchedulerType::IMMEDIATE);
@@ -84,6 +176,9 @@ void Application::run() {
 void Application::end() { delete m_instance; }
 
 Application::~Application() {
+  if (auto system_manager = SystemManager::get(); system_manager != nullptr) {
+    system_manager->remove_system<JobSystem>();
+  }
   Engine::get()->end();
   Time::get()->end();
   WindowManager::get()->end();

--- a/src/modules/application/application.hpp
+++ b/src/modules/application/application.hpp
@@ -1,12 +1,20 @@
 #pragma once
 
+#include <functional>
+
 namespace astralix {
 class Application {
 
 public:
+  using PreFrameCallback = std::function<void()>;
+
   static Application *init();
   void start();
   void run();
+
+  void set_pre_frame_callback(PreFrameCallback callback) {
+    m_pre_frame_callback = std::move(callback);
+  }
 
   static Application *get() { return m_instance; }
   static void end();
@@ -16,6 +24,7 @@ private:
   ~Application();
 
   static Application *m_instance;
+  PreFrameCallback m_pre_frame_callback;
 };
 
 } // namespace astralix

--- a/src/modules/jobs/CMakeLists.txt
+++ b/src/modules/jobs/CMakeLists.txt
@@ -1,0 +1,22 @@
+file(GLOB_RECURSE JOB_SRC ${CMAKE_CURRENT_SOURCE_DIR}/*.cpp)
+file(GLOB_RECURSE JOB_HEADERS ${CMAKE_CURRENT_SOURCE_DIR}/*.hpp)
+
+list(FILTER JOB_SRC EXCLUDE REGEX ".*\\.test\\.cpp$")
+list(FILTER JOB_HEADERS EXCLUDE REGEX ".*\\.test\\.hpp$")
+
+add_library(jobs STATIC ${JOB_SRC} ${JOB_HEADERS})
+
+target_include_directories(jobs
+  PUBLIC
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
+    $<INSTALL_INTERFACE:include/astralix/modules/jobs>
+)
+
+target_link_libraries(
+  jobs
+  PUBLIC
+  shared::ecs
+  shared::foundation
+)
+
+source_group(TREE "${CMAKE_CURRENT_SOURCE_DIR}" FILES ${JOB_SRC} ${JOB_HEADERS})

--- a/src/modules/jobs/systems/job-system/execution-policy.hpp
+++ b/src/modules/jobs/systems/job-system/execution-policy.hpp
@@ -1,0 +1,24 @@
+#pragma once
+
+#include <cstdint>
+
+namespace astralix::terrain {
+
+enum class ExecutionTrigger : uint8_t {
+  OneShot,
+  PerFrame,
+  OnDemand,
+};
+
+enum class QueueHint : uint8_t {
+  Main,
+  AsyncCompute,
+  Background,
+};
+
+struct ExecutionPolicy {
+  ExecutionTrigger trigger = ExecutionTrigger::OneShot;
+  QueueHint queue_hint = QueueHint::Main;
+};
+
+} // namespace astralix::terrain

--- a/src/modules/jobs/systems/job-system/job-callable.cpp
+++ b/src/modules/jobs/systems/job-system/job-callable.cpp
@@ -1,0 +1,1 @@
+#include "job-callable.hpp"

--- a/src/modules/jobs/systems/job-system/job-callable.hpp
+++ b/src/modules/jobs/systems/job-system/job-callable.hpp
@@ -1,0 +1,137 @@
+#pragma once
+
+#include <cstddef>
+#include <new>
+#include <type_traits>
+#include <utility>
+
+namespace astralix {
+
+class JobCallable {
+public:
+  static constexpr size_t INLINE_CAPACITY = 56u;
+
+  JobCallable() noexcept = default;
+
+  template <typename F>
+    requires(!std::is_same_v<std::decay_t<F>, JobCallable> &&
+             std::is_invocable_v<F>)
+  JobCallable(F &&callable) {
+    construct(std::forward<F>(callable));
+  }
+
+  ~JobCallable() { destroy(); }
+
+  JobCallable(JobCallable &&other) noexcept {
+    if (other.m_ops != nullptr) {
+      other.m_ops->move_into(other.m_storage, m_storage);
+      m_ops = other.m_ops;
+      other.m_ops = nullptr;
+    }
+  }
+
+  JobCallable &operator=(JobCallable &&other) noexcept {
+    if (this == &other) {
+      return *this;
+    }
+
+    destroy();
+
+    if (other.m_ops != nullptr) {
+      other.m_ops->move_into(other.m_storage, m_storage);
+      m_ops = other.m_ops;
+      other.m_ops = nullptr;
+    }
+
+    return *this;
+  }
+
+  JobCallable(const JobCallable &) = delete;
+  JobCallable &operator=(const JobCallable &) = delete;
+
+  void operator()() {
+    if (m_ops != nullptr) {
+      m_ops->invoke(m_storage);
+    }
+  }
+
+  explicit operator bool() const noexcept { return m_ops != nullptr; }
+
+private:
+  struct Ops {
+    void (*invoke)(void *storage);
+    void (*move_into)(void *source, void *destination);
+    void (*destroy)(void *storage);
+  };
+
+  template <typename F, bool Inline>
+  static const Ops &ops_for() {
+    static const Ops ops{
+        .invoke =
+            [](void *storage) {
+              if constexpr (Inline) {
+                (*static_cast<F *>(storage))();
+              } else {
+                (*(*static_cast<F **>(storage)))();
+              }
+            },
+        .move_into =
+            [](void *source, void *destination) {
+              if constexpr (Inline) {
+                auto *source_value = static_cast<F *>(source);
+                ::new (destination) F(std::move(*source_value));
+                source_value->~F();
+              } else {
+                *static_cast<F **>(destination) = *static_cast<F **>(source);
+                *static_cast<F **>(source) = nullptr;
+              }
+            },
+        .destroy =
+            [](void *storage) {
+              if constexpr (Inline) {
+                static_cast<F *>(storage)->~F();
+              } else {
+                F *pointer = *static_cast<F **>(storage);
+                if (pointer != nullptr) {
+                  pointer->~F();
+                  ::operator delete(pointer);
+                }
+              }
+            },
+    };
+
+    return ops;
+  }
+
+  template <typename F>
+  void construct(F &&callable) {
+    using Decayed = std::decay_t<F>;
+
+    constexpr bool fits_inline =
+        sizeof(Decayed) <= INLINE_CAPACITY &&
+        alignof(Decayed) <= alignof(std::max_align_t) &&
+        std::is_nothrow_move_constructible_v<Decayed>;
+
+    if constexpr (fits_inline) {
+      ::new (m_storage) Decayed(std::forward<F>(callable));
+      m_ops = &ops_for<Decayed, true>();
+    } else {
+      auto *heap_value = static_cast<Decayed *>(::operator new(sizeof(Decayed)));
+      ::new (heap_value) Decayed(std::forward<F>(callable));
+      *reinterpret_cast<Decayed **>(m_storage) = heap_value;
+      m_ops = &ops_for<Decayed, false>();
+    }
+  }
+
+  void destroy() noexcept {
+    if (m_ops != nullptr) {
+      m_ops->destroy(m_storage);
+      m_ops = nullptr;
+    }
+  }
+
+  alignas(std::max_align_t) unsigned char m_storage[INLINE_CAPACITY]{};
+  const Ops *m_ops = nullptr;
+};
+
+} // namespace astralix

--- a/src/modules/jobs/systems/job-system/job-system.cpp
+++ b/src/modules/jobs/systems/job-system/job-system.cpp
@@ -1,0 +1,732 @@
+#include "job-system.hpp"
+
+#include "assert.hpp"
+#include "log.hpp"
+
+#include <algorithm>
+#include <array>
+#include <chrono>
+#include <condition_variable>
+#include <deque>
+#include <exception>
+#include <mutex>
+#include <thread>
+#include <unordered_map>
+#include <utility>
+#include <vector>
+
+namespace astralix {
+
+namespace {
+
+constexpr std::array<JobPriority, 4> k_priority_order = {
+    JobPriority::Critical,
+    JobPriority::High,
+    JobPriority::Normal,
+    JobPriority::Low,
+};
+
+const char *queue_name(JobQueue queue) {
+  switch (queue) {
+    case JobQueue::Worker:
+      return "Worker";
+    case JobQueue::Main:
+      return "Main";
+    case JobQueue::Background:
+      return "Background";
+  }
+
+  return "Unknown";
+}
+
+const char *priority_name(JobPriority priority) {
+  switch (priority) {
+    case JobPriority::Low:
+      return "Low";
+    case JobPriority::Normal:
+      return "Normal";
+    case JobPriority::High:
+      return "High";
+    case JobPriority::Critical:
+      return "Critical";
+  }
+
+  return "Unknown";
+}
+
+size_t priority_index(JobPriority priority) {
+  switch (priority) {
+    case JobPriority::Low:
+      return 0u;
+    case JobPriority::Normal:
+      return 1u;
+    case JobPriority::High:
+      return 2u;
+    case JobPriority::Critical:
+      return 3u;
+  }
+
+  return 1u;
+}
+
+class JobSystemImpl {
+public:
+  explicit JobSystemImpl(JobSystem::Config config)
+      : m_main_thread_id(std::this_thread::get_id()) {
+    uint32_t worker_count = config.worker_count;
+    if (worker_count == 0u) {
+      const uint32_t hardware_threads = std::thread::hardware_concurrency();
+      worker_count = hardware_threads > 1u ? hardware_threads - 1u : 1u;
+    }
+
+    m_worker_threads.reserve(worker_count);
+    for (uint32_t index = 0; index < worker_count; ++index) {
+      m_worker_threads.emplace_back([this]() { worker_loop(); });
+    }
+
+    LOG_INFO("[JobSystem] initialized", "workers=", worker_count);
+  }
+
+  ~JobSystemImpl() = default;
+
+  JobHandle submit(
+      JobCallable work,
+      JobQueue queue,
+      JobPriority priority
+  ) {
+    return submit_locked({}, JobBarrier{}, std::move(work), queue, priority);
+  }
+
+  JobHandle submit_after(
+      std::span<const JobHandle> dependencies,
+      JobCallable work,
+      JobQueue queue,
+      JobPriority priority
+  ) {
+    return submit_locked(
+        dependencies, JobBarrier{}, std::move(work), queue, priority
+    );
+  }
+
+  JobHandle submit_after_barrier(
+      JobBarrier barrier,
+      JobCallable work,
+      JobQueue queue,
+      JobPriority priority
+  ) {
+    return submit_locked({}, barrier, std::move(work), queue, priority);
+  }
+
+  JobBarrier create_barrier(uint32_t expected_count) {
+    std::lock_guard lock(m_mutex);
+
+    JobBarrier barrier{.id = m_next_barrier_id++};
+    auto &record = m_barriers[barrier.id];
+    record.remaining = expected_count;
+    record.fired = expected_count == 0u;
+    LOG_DEBUG(
+        "[JobSystem] created barrier",
+        "barrier_id=", barrier.id,
+        "expected_count=", expected_count
+    );
+    return barrier;
+  }
+
+  void attach_to_barrier(JobHandle handle, JobBarrier barrier) {
+    if (!handle.is_valid() || !barrier.is_valid()) {
+      return;
+    }
+
+    std::lock_guard lock(m_mutex);
+
+    auto job_it = m_jobs.find(handle.id);
+    ASTRA_ENSURE(job_it == m_jobs.end(), "Unknown job handle");
+
+    auto barrier_it = m_barriers.find(barrier.id);
+    ASTRA_ENSURE(barrier_it == m_barriers.end(), "Unknown job barrier");
+
+    if (barrier_it->second.fired) {
+      return;
+    }
+
+    auto &job = job_it->second;
+    if (job.complete) {
+      complete_barrier_attachment_locked(barrier.id);
+      return;
+    }
+
+    if (std::find(
+            job.attached_barriers.begin(),
+            job.attached_barriers.end(),
+            barrier.id
+        ) != job.attached_barriers.end()) {
+      return;
+    }
+
+    job.attached_barriers.push_back(barrier.id);
+    LOG_DEBUG(
+        "[JobSystem] attached job to barrier",
+        "job_id=", handle.id,
+        "barrier_id=", barrier.id
+    );
+  }
+
+  bool is_complete(JobHandle handle) const {
+    if (!handle.is_valid()) {
+      return true;
+    }
+
+    std::lock_guard lock(m_mutex);
+
+    auto it = m_jobs.find(handle.id);
+    ASTRA_ENSURE(it == m_jobs.end(), "Unknown job handle");
+    return it->second.complete;
+  }
+
+  void wait(JobHandle handle) {
+    if (!handle.is_valid()) {
+      return;
+    }
+
+    for (;;) {
+      {
+        std::lock_guard lock(m_mutex);
+        auto it = m_jobs.find(handle.id);
+        ASTRA_ENSURE(it == m_jobs.end(), "Unknown job handle");
+        if (it->second.complete) {
+          if (it->second.exception != nullptr) {
+            std::rethrow_exception(it->second.exception);
+          }
+          return;
+        }
+      }
+
+      if (is_main_thread() && drain_main_queue(1u) > 0u) {
+        continue;
+      }
+
+      std::unique_lock lock(m_mutex);
+      m_completion_cv.wait_for(lock, std::chrono::milliseconds(1));
+    }
+  }
+
+  void wait_all(std::span<const JobHandle> handles) {
+    for (const auto &handle : handles) {
+      wait(handle);
+    }
+  }
+
+  void wait_barrier(JobBarrier barrier) {
+    if (!barrier.is_valid()) {
+      return;
+    }
+
+    for (;;) {
+      {
+        std::lock_guard lock(m_mutex);
+        auto it = m_barriers.find(barrier.id);
+        ASTRA_ENSURE(it == m_barriers.end(), "Unknown job barrier");
+        if (it->second.fired) {
+          return;
+        }
+      }
+
+      if (is_main_thread() && drain_main_queue(1u) > 0u) {
+        continue;
+      }
+
+      std::unique_lock lock(m_mutex);
+      m_completion_cv.wait_for(lock, std::chrono::milliseconds(1));
+    }
+  }
+
+  size_t drain_main_queue(size_t max_jobs) {
+    ASTRA_ENSURE(
+        !is_main_thread(),
+        "Main queue jobs must be drained from the initializing thread"
+    );
+
+    size_t drained = 0u;
+
+    while (drained < max_jobs) {
+      JobCallable work;
+      uint64_t job_id = 0u;
+
+      {
+        std::lock_guard lock(m_mutex);
+        job_id = pop_ready_job_locked(m_main_ready);
+        if (job_id == 0u) {
+          break;
+        }
+
+        auto &job = m_jobs.at(job_id);
+        job.queued = false;
+        job.running = true;
+        ++m_running_jobs;
+        work = std::move(job.work);
+      }
+
+      execute_job(job_id, std::move(work));
+      ++drained;
+    }
+
+    if (drained > 0u) {
+      LOG_DEBUG("[JobSystem] drained main queue", "jobs=", drained);
+    }
+
+    return drained;
+  }
+
+  bool has_pending_main_work() const {
+    std::lock_guard lock(m_mutex);
+    return !m_main_ready.empty();
+  }
+
+  void shutdown() {
+    wait_for_quiescence();
+
+    {
+      std::lock_guard lock(m_mutex);
+      m_stopping = true;
+    }
+
+    m_ready_cv.notify_all();
+
+    for (auto &worker : m_worker_threads) {
+      if (worker.joinable()) {
+        worker.join();
+      }
+    }
+
+    LOG_INFO("[JobSystem] shutdown complete");
+  }
+
+private:
+  struct ReadyQueues {
+    std::array<std::deque<uint64_t>, 4> by_priority;
+
+    bool empty() const {
+      for (const auto &queue : by_priority) {
+        if (!queue.empty()) {
+          return false;
+        }
+      }
+      return true;
+    }
+  };
+
+  struct JobRecord {
+    JobQueue queue = JobQueue::Worker;
+    JobPriority priority = JobPriority::Normal;
+    JobCallable work;
+    std::vector<uint64_t> dependents;
+    std::vector<uint64_t> attached_barriers;
+    uint32_t remaining_job_dependencies = 0u;
+    uint32_t remaining_barrier_dependencies = 0u;
+    bool queued = false;
+    bool running = false;
+    bool complete = false;
+    std::exception_ptr exception;
+  };
+
+  struct BarrierRecord {
+    uint32_t remaining = 0u;
+    bool fired = false;
+    std::vector<uint64_t> waiting_jobs;
+  };
+
+  JobHandle submit_locked(
+      std::span<const JobHandle> dependencies,
+      JobBarrier barrier,
+      JobCallable work,
+      JobQueue queue,
+      JobPriority priority
+  ) {
+    ASTRA_ENSURE(!work, "Cannot submit an empty job");
+
+    std::lock_guard lock(m_mutex);
+    ASTRA_ENSURE(m_stopping, "JobSystem is shutting down");
+
+    JobHandle handle{.id = m_next_job_id++};
+    auto &job = m_jobs[handle.id];
+    job.queue = queue;
+    job.priority = priority;
+    job.work = std::move(work);
+
+    for (const auto &dependency : dependencies) {
+      if (!dependency.is_valid()) {
+        continue;
+      }
+
+      auto dep_it = m_jobs.find(dependency.id);
+      ASTRA_ENSURE(dep_it == m_jobs.end(), "Unknown dependency job handle");
+
+      if (dep_it->second.complete) {
+        continue;
+      }
+
+      dep_it->second.dependents.push_back(handle.id);
+      ++job.remaining_job_dependencies;
+    }
+
+    if (barrier.is_valid()) {
+      auto barrier_it = m_barriers.find(barrier.id);
+      ASTRA_ENSURE(barrier_it == m_barriers.end(), "Unknown job barrier");
+
+      if (!barrier_it->second.fired) {
+        barrier_it->second.waiting_jobs.push_back(handle.id);
+        ++job.remaining_barrier_dependencies;
+      }
+    }
+
+    ++m_incomplete_jobs;
+
+    LOG_DEBUG(
+        "[JobSystem] submitted job",
+        "job_id=", handle.id,
+        "queue=", queue_name(queue),
+        "priority=", priority_name(priority),
+        "job_dependencies=", job.remaining_job_dependencies,
+        "barrier_dependencies=", job.remaining_barrier_dependencies
+    );
+
+    if (job.remaining_job_dependencies == 0u &&
+        job.remaining_barrier_dependencies == 0u) {
+      enqueue_ready_locked(handle.id, job.queue, job.priority);
+      m_ready_cv.notify_one();
+    }
+
+    return handle;
+  }
+
+  void worker_loop() {
+    for (;;) {
+      JobCallable work;
+      uint64_t job_id = 0u;
+
+      {
+        std::unique_lock lock(m_mutex);
+        m_ready_cv.wait(lock, [this]() {
+          return m_stopping || has_worker_ready_jobs_locked();
+        });
+
+        if (m_stopping && !has_worker_ready_jobs_locked()) {
+          return;
+        }
+
+        job_id = pop_ready_job_locked(m_worker_ready);
+        if (job_id == 0u) {
+          job_id = pop_ready_job_locked(m_background_ready);
+        }
+
+        if (job_id == 0u) {
+          continue;
+        }
+
+        auto &job = m_jobs.at(job_id);
+        job.queued = false;
+        job.running = true;
+        ++m_running_jobs;
+        work = std::move(job.work);
+      }
+
+      execute_job(job_id, std::move(work));
+    }
+  }
+
+  void execute_job(uint64_t job_id, JobCallable work) {
+    std::exception_ptr exception;
+
+    try {
+      if (work) {
+        work();
+      }
+    } catch (...) {
+      exception = std::current_exception();
+    }
+
+    std::lock_guard lock(m_mutex);
+    complete_job_locked(job_id, exception);
+  }
+
+  void complete_job_locked(uint64_t job_id, std::exception_ptr exception) {
+    auto job_it = m_jobs.find(job_id);
+    if (job_it == m_jobs.end() || job_it->second.complete) {
+      return;
+    }
+
+    auto &job = job_it->second;
+    job.complete = true;
+    job.running = false;
+    job.exception = exception;
+
+    if (exception != nullptr) {
+      LOG_ERROR(
+          "[JobSystem] job failed",
+          "job_id=", job_id,
+          "queue=", queue_name(job.queue),
+          "priority=", priority_name(job.priority)
+      );
+    }
+
+    if (m_running_jobs > 0u) {
+      --m_running_jobs;
+    }
+    if (m_incomplete_jobs > 0u) {
+      --m_incomplete_jobs;
+    }
+
+    auto dependents = std::move(job.dependents);
+    auto barriers = std::move(job.attached_barriers);
+    job.dependents.clear();
+    job.attached_barriers.clear();
+
+    for (uint64_t barrier_id : barriers) {
+      complete_barrier_attachment_locked(barrier_id);
+    }
+
+    for (uint64_t dependent_id : dependents) {
+      auto dependent_it = m_jobs.find(dependent_id);
+      if (dependent_it == m_jobs.end() || dependent_it->second.complete) {
+        continue;
+      }
+
+      auto &dependent = dependent_it->second;
+      if (dependent.remaining_job_dependencies > 0u) {
+        --dependent.remaining_job_dependencies;
+      }
+
+      if (dependent.remaining_job_dependencies == 0u &&
+          dependent.remaining_barrier_dependencies == 0u &&
+          !dependent.queued && !dependent.running) {
+        enqueue_ready_locked(
+            dependent_id, dependent.queue, dependent.priority
+        );
+      }
+    }
+
+    m_completion_cv.notify_all();
+    m_ready_cv.notify_all();
+  }
+
+  void complete_barrier_attachment_locked(uint64_t barrier_id) {
+    auto barrier_it = m_barriers.find(barrier_id);
+    if (barrier_it == m_barriers.end() || barrier_it->second.fired) {
+      return;
+    }
+
+    auto &barrier = barrier_it->second;
+    if (barrier.remaining > 0u) {
+      --barrier.remaining;
+    }
+
+    if (barrier.remaining != 0u) {
+      return;
+    }
+
+    barrier.fired = true;
+    auto waiting_jobs = std::move(barrier.waiting_jobs);
+    barrier.waiting_jobs.clear();
+
+    for (uint64_t waiting_job_id : waiting_jobs) {
+      auto job_it = m_jobs.find(waiting_job_id);
+      if (job_it == m_jobs.end() || job_it->second.complete) {
+        continue;
+      }
+
+      auto &job = job_it->second;
+      if (job.remaining_barrier_dependencies > 0u) {
+        --job.remaining_barrier_dependencies;
+      }
+
+      if (job.remaining_job_dependencies == 0u &&
+          job.remaining_barrier_dependencies == 0u &&
+          !job.queued && !job.running) {
+        enqueue_ready_locked(waiting_job_id, job.queue, job.priority);
+      }
+    }
+  }
+
+  void enqueue_ready_locked(
+      uint64_t job_id,
+      JobQueue queue,
+      JobPriority priority
+  ) {
+    auto &ready = ready_queue_locked(queue);
+    ready.by_priority[priority_index(priority)].push_back(job_id);
+    m_jobs.at(job_id).queued = true;
+  }
+
+  ReadyQueues &ready_queue_locked(JobQueue queue) {
+    switch (queue) {
+      case JobQueue::Worker:
+        return m_worker_ready;
+      case JobQueue::Main:
+        return m_main_ready;
+      case JobQueue::Background:
+        return m_background_ready;
+    }
+
+    return m_worker_ready;
+  }
+
+  uint64_t pop_ready_job_locked(ReadyQueues &ready) {
+    for (JobPriority priority : k_priority_order) {
+      auto &bucket = ready.by_priority[priority_index(priority)];
+      if (bucket.empty()) {
+        continue;
+      }
+
+      uint64_t job_id = bucket.front();
+      bucket.pop_front();
+      return job_id;
+    }
+
+    return 0u;
+  }
+
+  bool has_worker_ready_jobs_locked() const {
+    return !m_worker_ready.empty() || !m_background_ready.empty();
+  }
+
+  void wait_for_quiescence() {
+    for (;;) {
+      {
+        std::lock_guard lock(m_mutex);
+        if (m_incomplete_jobs == 0u) {
+          return;
+        }
+      }
+
+      if (is_main_thread() && drain_main_queue(1u) > 0u) {
+        continue;
+      }
+
+      std::unique_lock lock(m_mutex);
+      m_completion_cv.wait_for(lock, std::chrono::milliseconds(1));
+    }
+  }
+
+  bool is_main_thread() const noexcept {
+    return std::this_thread::get_id() == m_main_thread_id;
+  }
+
+  std::thread::id m_main_thread_id;
+  mutable std::mutex m_mutex;
+  std::condition_variable m_ready_cv;
+  std::condition_variable m_completion_cv;
+  std::vector<std::thread> m_worker_threads;
+  std::unordered_map<uint64_t, JobRecord> m_jobs;
+  std::unordered_map<uint64_t, BarrierRecord> m_barriers;
+  ReadyQueues m_worker_ready;
+  ReadyQueues m_main_ready;
+  ReadyQueues m_background_ready;
+  uint64_t m_next_job_id = 1u;
+  uint64_t m_next_barrier_id = 1u;
+  size_t m_incomplete_jobs = 0u;
+  size_t m_running_jobs = 0u;
+  bool m_stopping = false;
+};
+
+} // namespace
+
+JobSystem *JobSystem::m_instance = nullptr;
+static JobSystemImpl *g_job_system_impl = nullptr;
+
+JobSystem::JobSystem() = default;
+
+JobSystem::JobSystem(Config config) : m_config(config) {}
+
+JobSystem::~JobSystem() = default;
+
+JobSystem *JobSystem::get() { return m_instance; }
+
+void JobSystem::start() {
+  if (m_instance == nullptr) {
+    m_instance = this;
+  }
+
+  if (g_job_system_impl == nullptr) {
+    g_job_system_impl = new JobSystemImpl(m_config);
+  }
+}
+
+void JobSystem::end() {
+  if (g_job_system_impl != nullptr) {
+    g_job_system_impl->shutdown();
+    delete g_job_system_impl;
+    g_job_system_impl = nullptr;
+  }
+
+  if (m_instance == this) {
+    m_instance = nullptr;
+  }
+}
+
+void JobSystem::fixed_update(double fixed_dt) { (void)fixed_dt; }
+
+void JobSystem::pre_update(double dt) { (void)dt; }
+
+void JobSystem::update(double dt) { (void)dt; }
+
+JobHandle JobSystem::submit(
+    JobCallable work,
+    JobQueue queue,
+    JobPriority priority
+) {
+  return g_job_system_impl->submit(std::move(work), queue, priority);
+}
+
+JobHandle JobSystem::submit_after(
+    std::span<const JobHandle> dependencies,
+    JobCallable work,
+    JobQueue queue,
+    JobPriority priority
+) {
+  return g_job_system_impl->submit_after(
+      dependencies, std::move(work), queue, priority
+  );
+}
+
+JobBarrier JobSystem::create_barrier(uint32_t expected_count) {
+  return g_job_system_impl->create_barrier(expected_count);
+}
+
+void JobSystem::attach_to_barrier(JobHandle handle, JobBarrier barrier) {
+  g_job_system_impl->attach_to_barrier(handle, barrier);
+}
+
+JobHandle JobSystem::submit_after_barrier(
+    JobBarrier barrier,
+    JobCallable work,
+    JobQueue queue,
+    JobPriority priority
+) {
+  return g_job_system_impl->submit_after_barrier(
+      barrier, std::move(work), queue, priority
+  );
+}
+
+bool JobSystem::is_complete(JobHandle handle) const {
+  return g_job_system_impl->is_complete(handle);
+}
+
+void JobSystem::wait(JobHandle handle) { g_job_system_impl->wait(handle); }
+
+void JobSystem::wait_all(std::span<const JobHandle> handles) {
+  g_job_system_impl->wait_all(handles);
+}
+
+void JobSystem::wait_barrier(JobBarrier barrier) {
+  g_job_system_impl->wait_barrier(barrier);
+}
+
+size_t JobSystem::drain_main_queue(size_t max_jobs) {
+  return g_job_system_impl->drain_main_queue(max_jobs);
+}
+
+bool JobSystem::has_pending_main_work() const {
+  return g_job_system_impl->has_pending_main_work();
+}
+
+} // namespace astralix

--- a/src/modules/jobs/systems/job-system/job-system.hpp
+++ b/src/modules/jobs/systems/job-system/job-system.hpp
@@ -1,0 +1,95 @@
+#pragma once
+
+#include "job-callable.hpp"
+#include "systems/system.hpp"
+
+#include <cstdint>
+#include <limits>
+#include <span>
+
+namespace astralix {
+
+enum class JobPriority : uint8_t {
+  Low,
+  Normal,
+  High,
+  Critical,
+};
+
+enum class JobQueue : uint8_t {
+  Worker,
+  Main,
+  Background,
+};
+
+struct JobHandle {
+  uint64_t id = 0;
+
+  bool is_valid() const noexcept { return id != 0; }
+};
+
+struct JobBarrier {
+  uint64_t id = 0;
+
+  bool is_valid() const noexcept { return id != 0; }
+};
+
+class JobSystem : public System<JobSystem> {
+public:
+  struct Config {
+    uint32_t worker_count = 0;
+  };
+
+  JobSystem();
+  explicit JobSystem(Config config);
+  ~JobSystem() override;
+
+  static JobSystem *get();
+
+  void start() override;
+  void end() override;
+  void fixed_update(double fixed_dt) override;
+  void pre_update(double dt) override;
+  void update(double dt) override;
+
+  JobHandle submit(
+      JobCallable work,
+      JobQueue queue = JobQueue::Worker,
+      JobPriority priority = JobPriority::Normal
+  );
+
+  JobHandle submit_after(
+      std::span<const JobHandle> dependencies,
+      JobCallable work,
+      JobQueue queue = JobQueue::Worker,
+      JobPriority priority = JobPriority::Normal
+  );
+
+  JobBarrier create_barrier(uint32_t expected_count);
+  void attach_to_barrier(JobHandle handle, JobBarrier barrier);
+
+  JobHandle submit_after_barrier(
+      JobBarrier barrier,
+      JobCallable work,
+      JobQueue queue = JobQueue::Worker,
+      JobPriority priority = JobPriority::Normal
+  );
+
+  bool is_complete(JobHandle handle) const;
+  void wait(JobHandle handle);
+  void wait_all(std::span<const JobHandle> handles);
+  void wait_barrier(JobBarrier barrier);
+
+  size_t
+  drain_main_queue(size_t max_jobs = std::numeric_limits<size_t>::max());
+  bool has_pending_main_work() const;
+
+private:
+  JobSystem(const JobSystem &) = delete;
+  JobSystem &operator=(const JobSystem &) = delete;
+
+  Config m_config;
+  static JobSystem *m_instance;
+};
+
+} // namespace astralix

--- a/src/modules/window/events/mouse.hpp
+++ b/src/modules/window/events/mouse.hpp
@@ -36,6 +36,13 @@ public:
     };
   };
 
+  Position wheel_delta() const {
+    return Position{
+        m_wheel_delta.x,
+        m_wheel_delta.y,
+    };
+  }
+
   Position position() const { return m_position; }
 
   void set_position(Position position) {
@@ -64,6 +71,11 @@ public:
     m_changed = true;
   }
 
+  void apply_wheel(Position position) {
+    m_wheel_delta.x += position.x;
+    m_wheel_delta.y += position.y;
+  }
+
   void set_button_state(MouseButton button, bool down);
 
   bool is_button_down(MouseButton button) const;
@@ -72,6 +84,7 @@ public:
 
   void reset_delta() {
     m_delta = {.x = 0, .y = 0};
+    m_wheel_delta = {.x = 0, .y = 0};
     m_changed = false;
 
     for (auto &state : m_button_states) {
@@ -87,6 +100,7 @@ public:
 
 private:
   Position m_delta;
+  Position m_wheel_delta{.x = 0.0, .y = 0.0};
   Position m_position;
   Position m_last;
   ButtonState m_button_states[static_cast<size_t>(MouseButton::Count)];

--- a/src/modules/window/managers/window-manager.hpp
+++ b/src/modules/window/managers/window-manager.hpp
@@ -62,6 +62,10 @@ namespace input {
   return window_manager()->active_window()->mouse()->delta();
 }
 
+[[nodiscard]] static inline const input::Mouse::Position MOUSE_WHEEL_DELTA() {
+  return window_manager()->active_window()->mouse()->wheel_delta();
+}
+
 [[nodiscard]] static inline const input::Mouse::Position CURSOR_POSITION() {
   return window_manager()->active_window()->mouse()->position();
 }

--- a/src/modules/window/window.cpp
+++ b/src/modules/window/window.cpp
@@ -260,6 +260,9 @@ void Window::scroll_callback(GLFWwindow *window, double xoffset,
     mods |= GLFW_MOD_SUPER;
   }
 
+  self->m_mouse->apply_wheel(
+      input::Mouse::Position{.x = xoffset, .y = yoffset}
+  );
   auto event = MouseWheelEvent(
       xoffset, yoffset, self->id(), input::KeyModifiers::from_glfw(mods));
   EventDispatcher::get()->dispatch(&event);

--- a/src/shared/allocators/arena.test.cpp
+++ b/src/shared/allocators/arena.test.cpp
@@ -1,13 +1,13 @@
 #include "arena.hpp"
 #include "exceptions/base-exception.hpp"
-#include "faker-cxx/faker.h"
-#include "log.hpp"
+#include "helpers/random.hpp"
 #include <gtest/gtest.h>
 
 using namespace astralix;
+using namespace astralix::testing;
 
 TEST(ElasticArenaTest, EnsureNoPoolIncreasehenBlockEqualsCapacity) {
-  const auto page_size = faker::number::integer(32, 1024);
+  const auto page_size = random_integer(32, 1024);
   astralix::ElasticArena elastic_arena(page_size);
 
   const auto block_size = page_size;
@@ -23,9 +23,9 @@ TEST(ElasticArenaTest, EnsureNoPoolIncreasehenBlockEqualsCapacity) {
 }
 
 TEST(ElasticArenaTest, EnsurePoolOverflowWhenIncreasedCapacityIsFull) {
-  const auto page_size = faker::number::integer(1, 32);
+  const auto page_size = random_integer(1, 32);
 
-  auto max_capacity_increase = faker::number::integer(1, 12);
+  auto max_capacity_increase = random_integer(1, 12);
 
   astralix::ElasticArena elastic_arena(page_size, max_capacity_increase);
 
@@ -52,9 +52,9 @@ TEST(ElasticArenaTest, EnsurePoolOverflowWhenIncreasedCapacityIsFull) {
 }
 
 TEST(ElasticArenaTest, PoolIncreaseWhenBlockGreatherThanCapacity) {
-  const auto page_size = faker::number::integer(32, 1024);
+  const auto page_size = random_integer(32, 1024);
 
-  auto max_capacity_increase = faker::number::integer(page_size);
+  auto max_capacity_increase = random_integer(1, page_size);
 
   astralix::ElasticArena elastic_arena(page_size, max_capacity_increase);
 
@@ -112,11 +112,11 @@ TEST(ElasticArenaTest, ResetClearsCapacityIncreaseCount) {
 }
 
 TEST(ElasticStackArenaTest, SinglePushPop) {
-  const auto page_size = faker::number::integer(32, 1024);
+  const auto page_size = random_integer(32, 1024);
   astralix::ElasticArena elastic_arena(page_size);
   astralix::ElasticStackArena stack_arena(elastic_arena);
 
-  const auto block_size = faker::number::integer(32, page_size);
+  const auto block_size = random_integer(32, page_size);
 
   // Initial memory should be 0
   EXPECT_EQ(stack_arena.allocated_memory(), 0);
@@ -133,7 +133,7 @@ TEST(ElasticStackArenaTest, SinglePushPop) {
 }
 
 TEST(ElasticStackArenaTest, MultiPushWithLinearPop) {
-  const auto page_size = faker::number::integer(32, 1024);
+  const auto page_size = random_integer(32, 1024);
 
   astralix::ElasticArena elastic_arena(page_size);
 
@@ -144,7 +144,7 @@ TEST(ElasticStackArenaTest, MultiPushWithLinearPop) {
   //
   EXPECT_EQ(stack_arena.allocated_memory(), elastic_arena.allocated_memory());
 
-  const auto block_size = faker::number::integer(32, 1024);
+  const auto block_size = random_integer(32, 1024);
 
   int allocations = 0;
 
@@ -167,10 +167,10 @@ TEST(ElasticStackArenaTest, MultiPushWithLinearPop) {
 }
 
 TEST(ElasticStackArenaTest, MultiplePushWithPartialPop) {
-  const auto page_size = faker::number::integer(32, 1024);
+  const auto page_size = random_integer(32, 1024);
 
-  const auto max_allocations = faker::number::integer(32, page_size);
-  const auto min_allocations = faker::number::integer(32, max_allocations);
+  const auto max_allocations = random_integer(32, page_size);
+  const auto min_allocations = random_integer(32, max_allocations);
 
   astralix::ElasticArena elastic_arena(page_size, max_allocations);
   astralix::ElasticStackArena stack_arena(elastic_arena);
@@ -218,8 +218,8 @@ TEST(ElasticStackArenaTest, ClearReleasesAllBlocks) {
 }
 
 TEST(Str, EnsureEquality) {
-  const auto sso_text_length = faker::number::integer(1, 22);
-  const auto sso_text = faker::string::alpha(sso_text_length);
+  const auto sso_text_length = random_integer(1, 22);
+  const auto sso_text = random_alpha(sso_text_length);
 
   auto arena = ElasticArena(KB(1));
 
@@ -235,7 +235,7 @@ TEST(Str, EnsureEquality) {
   EXPECT_EQ(sso_str.size(), 0);
   EXPECT_EQ(sso_str.allocated_memory(), 0);
 
-  const auto text = faker::lorem::sentences();
+  const auto text = random_sentences();
 
   Str str = Str::from_initializer({arena, text.c_str()});
 
@@ -244,8 +244,8 @@ TEST(Str, EnsureEquality) {
 }
 
 TEST(Str, SmallStringShouldHitSSO) {
-  const auto sso_text_length = faker::number::integer(1, 22);
-  const auto text = faker::string::alpha(sso_text_length);
+  const auto sso_text_length = random_integer(1, 22);
+  const auto text = random_alpha(sso_text_length);
 
   auto arena = ElasticArena(KB(1));
 
@@ -258,7 +258,7 @@ TEST(Str, SmallStringShouldHitSSO) {
 }
 
 TEST(Str, LargeStringShouldNotHitSSO) {
-  const auto text = faker::lorem::sentences();
+  const auto text = random_sentences();
 
   auto arena = ElasticArena(KB(1));
 
@@ -271,8 +271,8 @@ TEST(Str, LargeStringShouldNotHitSSO) {
 }
 
 TEST(Str, AppendWithSmallStringShouldHitSSO) {
-  const auto sso_text_length = faker::number::integer(1, 22);
-  const auto text = faker::string::alpha(sso_text_length);
+  const auto sso_text_length = random_integer(1, 22);
+  const auto text = random_alpha(sso_text_length);
 
   auto arena = ElasticArena(KB(1));
   Str str = Str::from_initializer({arena, text.c_str()});
@@ -282,7 +282,7 @@ TEST(Str, AppendWithSmallStringShouldHitSSO) {
   EXPECT_TRUE(str.is_sso());
   EXPECT_EQ(other.size(), 0);
 
-  const auto sub_length = faker::number::integer(1, sso_text_length);
+  const auto sub_length = random_integer(1, sso_text_length);
   other.append(str, sub_length);
 
   EXPECT_EQ(other.size(), sub_length);
@@ -303,7 +303,7 @@ TEST(Str, AppendWithSmallStringShouldHitSSO) {
 }
 
 TEST(Str, AppendWithLargeStringShouldNotHitSSO) {
-  const auto text = faker::lorem::sentences();
+  const auto text = random_sentences();
 
   auto arena = ElasticArena(KB(1));
 
@@ -314,7 +314,7 @@ TEST(Str, AppendWithLargeStringShouldNotHitSSO) {
   EXPECT_FALSE(str.is_sso());
   EXPECT_EQ(other.size(), 0);
 
-  const auto sub_length = faker::number::integer(23, (int)text.size());
+  const auto sub_length = random_integer(23, (int)text.size());
   other.append(str, sub_length);
 
   EXPECT_EQ(other.size(), sub_length);
@@ -337,7 +337,7 @@ TEST(Str, AppendWithLargeStringShouldNotHitSSO) {
 }
 
 TEST(Str, AppendCStr) {
-  const auto text = faker::lorem::sentences();
+  const auto text = random_sentences();
 
   auto arena = ElasticArena(KB(1));
 
@@ -347,7 +347,7 @@ TEST(Str, AppendCStr) {
   EXPECT_FALSE(str.is_sso());
   EXPECT_EQ(other.size(), 0);
 
-  const auto sub_length = faker::number::integer(23, (int)text.size());
+  const auto sub_length = random_integer(23, (int)text.size());
   other.append(str.c_str(), sub_length);
 
   EXPECT_EQ(other.size(), sub_length);
@@ -374,7 +374,7 @@ TEST(Str, AppendLargeStringToEmptyStr) {
 
   Str empty_str(arena);
 
-  const auto large_text = faker::lorem::sentences();
+  const auto large_text = random_sentences();
   empty_str.append(large_text.c_str(), large_text.size());
 
   EXPECT_FALSE(empty_str.is_sso());
@@ -390,7 +390,7 @@ TEST(Str, EmptyStringAppend) {
   EXPECT_EQ(str.size(), 0);
   EXPECT_STREQ(str.c_str(), "");
 
-  const auto text = faker::string::alpha(10);
+  const auto text = random_alpha(10);
   str.append(text.c_str(), text.size());
   EXPECT_TRUE(str.is_sso());
   EXPECT_EQ(str, text);
@@ -399,8 +399,8 @@ TEST(Str, EmptyStringAppend) {
 TEST(Str, AppendSmallToSmallWithinSSO) {
   auto arena = ElasticArena(KB(1));
 
-  const auto str_text = faker::string::alpha(10);
-  const auto other_text = faker::string::alpha(10); // 10 + 10 = 20 <= 22
+  const auto str_text = random_alpha(10);
+  const auto other_text = random_alpha(10); // 10 + 10 = 20 <= 22
 
   Str str(str_text.c_str(), arena);
   Str other(other_text.c_str(), arena);
@@ -415,8 +415,8 @@ TEST(Str, AppendSmallToSmallWithinSSO) {
 TEST(Str, AppendSmallToSmallExceedingSSO) {
   auto arena = ElasticArena(KB(1));
 
-  const auto str_text = faker::string::alpha(15);
-  const auto other_text = faker::string::alpha(10); // 15 + 10 = 25 > 22
+  const auto str_text = random_alpha(15);
+  const auto other_text = random_alpha(10); // 15 + 10 = 25 > 22
 
   Str str(str_text.c_str(), arena);
   Str other(other_text.c_str(), arena);
@@ -431,12 +431,12 @@ TEST(Str, AppendSmallToSmallExceedingSSO) {
 TEST(Str, NullTermination) {
   auto arena = ElasticArena(KB(1));
 
-  const auto small_text = faker::string::alpha(10);
+  const auto small_text = random_alpha(10);
   Str small_str(small_text.c_str(), arena);
   EXPECT_EQ(std::strlen(small_str.c_str()), small_text.size());
   EXPECT_EQ(small_str.c_str()[small_text.size()], '\0');
 
-  const auto large_text = faker::lorem::sentences();
+  const auto large_text = random_sentences();
   Str large_str(large_text.c_str(), arena);
   EXPECT_EQ(std::strlen(large_str.c_str()), large_text.size());
   EXPECT_EQ(large_str.c_str()[large_text.size()], '\0');
@@ -445,8 +445,8 @@ TEST(Str, NullTermination) {
 TEST(Str, AppendLargeToSmall) {
   auto arena = ElasticArena(KB(1));
 
-  const auto small_text = faker::string::alpha(10);
-  const auto large_text = faker::lorem::sentences();
+  const auto small_text = random_alpha(10);
+  const auto large_text = random_sentences();
 
   Str small_str(small_text.c_str(), arena);
   Str large_str(large_text.c_str(), arena);
@@ -460,8 +460,8 @@ TEST(Str, AppendLargeToSmall) {
 TEST(Str, AppendSmallToLarge) {
   auto arena = ElasticArena(KB(1));
 
-  const auto large_text = faker::lorem::sentences();
-  const auto small_text = faker::string::alpha(10);
+  const auto large_text = random_sentences();
+  const auto small_text = random_alpha(10);
 
   Str large_str(large_text.c_str(), arena);
   Str small_str(small_text.c_str(), arena);
@@ -475,8 +475,8 @@ TEST(Str, AppendSmallToLarge) {
 TEST(Str, AppendLargeToLarge) {
   auto arena = ElasticArena(KB(1));
 
-  const auto str_text = faker::lorem::sentences();
-  const auto other_text = faker::lorem::sentences();
+  const auto str_text = random_sentences();
+  const auto other_text = random_sentences();
 
   Str str(str_text.c_str(), arena);
   Str other(other_text.c_str(), arena);
@@ -491,8 +491,8 @@ TEST(Str, AppendLargeToLarge) {
 TEST(Str, OperatorPlusEqualStr) {
   auto arena = ElasticArena(KB(1));
 
-  const auto str_text = faker::string::alpha(10);
-  const auto other_text = faker::string::alpha(10); // 10 + 10 = 20 <= 22
+  const auto str_text = random_alpha(10);
+  const auto other_text = random_alpha(10); // 10 + 10 = 20 <= 22
 
   Str str(str_text.c_str(), arena);
   Str other(other_text.c_str(), arena);
@@ -507,8 +507,8 @@ TEST(Str, OperatorPlusEqualStr) {
 TEST(Str, OperatorPlusEqualCStr) {
   auto arena = ElasticArena(KB(1));
 
-  const auto str_text = faker::string::alpha(10);
-  const auto other_text = faker::string::alpha(10);
+  const auto str_text = random_alpha(10);
+  const auto other_text = random_alpha(10);
 
   Str str(str_text.c_str(), arena);
   str += other_text.c_str();
@@ -521,7 +521,7 @@ TEST(Str, OperatorPlusEqualCStr) {
 TEST(Str, AssignmentWithCStr) {
   auto arena = ElasticArena(KB(1));
 
-  const auto text = faker::lorem::sentences();
+  const auto text = random_sentences();
 
   Str str(arena);
   str = text.c_str();
@@ -536,7 +536,7 @@ TEST(Str, AssignmentWithCStr) {
 TEST(Str, ReleaseSSOString) {
   auto arena = ElasticArena(KB(1));
 
-  const auto text = faker::string::alpha(10);
+  const auto text = random_alpha(10);
 
   Str str(text.c_str(), arena);
 
@@ -550,7 +550,7 @@ TEST(Str, ReleaseSSOString) {
 TEST(Str, ReleaseNonSSOString) {
   auto arena = ElasticArena(KB(1));
 
-  const auto text = faker::lorem::sentences();
+  const auto text = random_sentences();
   Str str(text.c_str(), arena);
   EXPECT_FALSE(str.is_sso());
   str.release();
@@ -561,7 +561,7 @@ TEST(Str, ReleaseNonSSOString) {
 TEST(Str, SelfAppend) {
   auto arena = ElasticArena(KB(1));
 
-  const auto text = faker::string::alpha(10);
+  const auto text = random_alpha(10);
   Str str(text.c_str(), arena);
   str.append(str, str.size());
 

--- a/src/shared/ecs/managers/system-manager.cpp
+++ b/src/shared/ecs/managers/system-manager.cpp
@@ -15,6 +15,9 @@ void SystemManager::start() {
   ASTRA_PROFILE_N("SystemManager::start");
   for (ISystem_ptr system : m_system_work_order) {
     if (system->m_enabled) {
+      ASTRA_PROFILE_N("System::start");
+      const char *name = system->get_system_type_name();
+      ASTRA_PROFILE_TEXT(name, strlen(name));
       system->start();
     }
   }

--- a/src/shared/ecs/managers/system-manager.hpp
+++ b/src/shared/ecs/managers/system-manager.hpp
@@ -9,6 +9,7 @@
 #include "systems/isystem.hpp"
 #include "unordered_map"
 #include "vector"
+#include <algorithm>
 #include <vector>
 
 namespace astralix {
@@ -93,6 +94,39 @@ public:
     }
 
     this->add_system_dependency(target, std::forward<Dependencies>(dependencies)...);
+  }
+
+  template <class T>
+  void remove_system() {
+    const SystemTypeID type_id = T::system_type_id();
+    auto it = m_system_table.find(type_id);
+    if (it == m_system_table.end()) return;
+
+    it->second->end();
+
+    std::erase_if(m_system_work_order,
+      [type_id](const ISystem_ptr& system) {
+        return system->get_system_type_id() == type_id;
+      });
+
+    if (type_id < m_system_dependency_table.size()) {
+      for (auto& row : m_system_dependency_table) {
+        if (type_id < row.size()) row[type_id] = false;
+      }
+      std::fill(m_system_dependency_table[type_id].begin(),
+                m_system_dependency_table[type_id].end(), false);
+    }
+
+    m_system_table.erase(it);
+    update_system_work_order();
+  }
+
+  template <class T>
+  void start_system() {
+    auto it = m_system_table.find(T::system_type_id());
+    if (it != m_system_table.end()) {
+      it->second->start();
+    }
   }
 
   void update_system_work_order();

--- a/src/shared/ecs/systems/isystem.hpp
+++ b/src/shared/ecs/systems/isystem.hpp
@@ -36,6 +36,7 @@ public:
   virtual inline const char *get_system_type_name() const = 0;
 
   virtual void start() = 0;
+  virtual void end() {}
   virtual void fixed_update(double fixed_dt) = 0;
   virtual void pre_update(double dt) = 0;
   virtual void update(double dt) = 0;

--- a/src/shared/foundation/assert.hpp
+++ b/src/shared/foundation/assert.hpp
@@ -76,6 +76,10 @@ static size_t levenshtein_distance(const std::string &str_value,
   throw BaseException(__FILE__, __FUNCTION__, __LINE__,                        \
                       build_exception_message(__VA_ARGS__));
 
+#define ASTRA_EXCEPTION_META(metadata, ...)                                    \
+  throw BaseException(__FILE__, __FUNCTION__, __LINE__,                        \
+                      build_exception_message(__VA_ARGS__), metadata);
+
 #define ASTRA_ENSURE(EXPRESSION, ...)                                          \
   if (EXPRESSION) {                                                            \
     throw BaseException(__FILE__, __FUNCTION__, __LINE__,                      \

--- a/src/shared/foundation/exceptions/base-exception.cpp
+++ b/src/shared/foundation/exceptions/base-exception.cpp
@@ -6,13 +6,32 @@ namespace astralix {
 
 BaseException::BaseException(const char *file, const char *function, int line,
                              std::string message)
-    : m_line(line), m_file(file), m_function(function), m_message(message) {
+    : m_line(line), m_file(file), m_function(function), m_message(std::move(message)) {
+  format();
+}
+
+BaseException::BaseException(const char *file, const char *function, int line,
+                             std::string message, ExceptionMetadata metadata)
+    : m_line(line), m_file(file), m_function(function),
+      m_message(std::move(message)), m_metadata(std::move(metadata)) {
+  format();
+}
+
+void BaseException::format() {
   std::ostringstream oss;
   oss << BOLD << RED << "\n=== Astralix Exception ===" << RESET << "\n\n"
       << BOLD << CYAN << "File: " << RESET << m_file << "\n"
       << BOLD << CYAN << "Method: " << RESET << m_function << "\n"
-      << BOLD << CYAN << "Line: " << RESET << m_line << "\n\n"
-      << BOLD << YELLOW << "Message: " << RESET << m_message << "\n\n"
+      << BOLD << CYAN << "Line: " << RESET << m_line << "\n";
+
+  if (!m_metadata.empty()) {
+    oss << "\n" << BOLD << MAGENTA << "Metadata:" << RESET << "\n";
+    for (const auto &[key, value] : m_metadata) {
+      oss << "  " << BOLD << CYAN << key << ": " << RESET << value << "\n";
+    }
+  }
+
+  oss << "\n" << BOLD << YELLOW << "Message: " << RESET << m_message << "\n\n"
       << BOLD << RED << "==========================" << RESET;
   m_formatted_message = oss.str();
 }

--- a/src/shared/foundation/exceptions/base-exception.hpp
+++ b/src/shared/foundation/exceptions/base-exception.hpp
@@ -2,13 +2,20 @@
 #include "exception"
 #include "string"
 #include <sstream>
+#include <vector>
+#include <utility>
 
 namespace astralix {
+
+using ExceptionMetadata = std::vector<std::pair<std::string, std::string>>;
 
 class BaseException : public std::exception {
 public:
   BaseException(const char *file, const char *function, int line,
                 std::string message);
+
+  BaseException(const char *file, const char *function, int line,
+                std::string message, ExceptionMetadata metadata);
 
   const char *what() const noexcept override {
     return m_formatted_message.c_str();
@@ -17,12 +24,16 @@ public:
   const char *file() const noexcept { return m_file; }
   const char *function() const noexcept { return m_function; }
   int line() const noexcept { return m_line; }
+  const ExceptionMetadata &metadata() const noexcept { return m_metadata; }
 
 private:
+  void format();
+
   std::string m_message;
   int m_line;
   const char *m_file;
   const char *m_function;
+  ExceptionMetadata m_metadata;
 
   std::string m_formatted_message;
 };

--- a/src/shared/foundation/log.hpp
+++ b/src/shared/foundation/log.hpp
@@ -11,6 +11,7 @@
 #define RESET "\033[0m"
 #define RED "\033[31m"
 #define YELLOW "\033[33m"
+#define MAGENTA "\033[35m"
 #define CYAN "\033[36m"
 #define BOLD "\033[1m"
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -16,18 +16,13 @@ set(SHARED_DIR "${CMAKE_SOURCE_DIR}/../src/shared")
 set(AXSLC_DIR "${CMAKE_SOURCE_DIR}/../axslc")
 set(AXGEN_DIR "${CMAKE_SOURCE_DIR}/../axgen")
 set(AXGEN_SRC_DIR "${AXGEN_DIR}/src")
-set(FAKER_CXX_DIR "${CMAKE_SOURCE_DIR}/../external/faker-cxx")
-set(GOOGLETEST_DIR "${FAKER_CXX_DIR}/externals/googletest")
+set(GTest_DIR "${VCPKG_INSTALLED_ROOT}/share/gtest")
 
 include("${MODULES_DIR}/streams/serialization-formats.cmake")
 
 set(ASTRALIX_TEST_SERIALIZATION_FORMATS Json Yaml Toml Xml)
 
-set(BUILD_TESTING OFF CACHE BOOL "" FORCE)
-add_subdirectory("${FAKER_CXX_DIR}" "${CMAKE_CURRENT_BINARY_DIR}/faker-cxx"
-                 EXCLUDE_FROM_ALL)
-add_subdirectory("${GOOGLETEST_DIR}" "${CMAKE_CURRENT_BINARY_DIR}/googletest"
-                 EXCLUDE_FROM_ALL)
+find_package(GTest CONFIG REQUIRED)
 find_package(glad CONFIG REQUIRED)
 find_package(unofficial-shaderc CONFIG REQUIRED)
 
@@ -77,6 +72,7 @@ add_executable(astralix_tests
   ${SERIALIZATION_SRC})
 
 target_include_directories(astralix_tests PRIVATE
+  "${CMAKE_SOURCE_DIR}"
   "${CMAKE_SOURCE_DIR}/../src/modules/renderer"
   "${CMAKE_SOURCE_DIR}/../src/shared"
   "${CMAKE_SOURCE_DIR}/../src/assets/.astralix/generated"
@@ -97,9 +93,8 @@ target_include_directories(astralix_tests PRIVATE
   "${AXGEN_SRC_DIR}")
 
 target_link_libraries(astralix_tests PRIVATE
-  faker-cxx
-  gtest
-  gtest_main
+  GTest::gtest
+  GTest::gtest_main
   glad::glad)
 
 target_compile_definitions(astralix_tests PRIVATE

--- a/tests/helpers/random.hpp
+++ b/tests/helpers/random.hpp
@@ -1,0 +1,52 @@
+#pragma once
+
+#include <random>
+#include <string>
+
+namespace astralix::testing {
+
+inline std::mt19937 &rng() {
+  static std::mt19937 generator{std::random_device{}()};
+  return generator;
+}
+
+inline int random_integer(int min, int max) {
+  std::uniform_int_distribution<int> distribution(min, max);
+  return distribution(rng());
+}
+
+inline std::string random_alpha(int length) {
+  static constexpr char alphabet[] =
+      "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ";
+  std::uniform_int_distribution<int> distribution(0, sizeof(alphabet) - 2);
+  std::string result;
+  result.reserve(static_cast<std::string::size_type>(length));
+  for (int i = 0; i < length; ++i)
+    result += alphabet[distribution(rng())];
+  return result;
+}
+
+inline std::string random_sentences() {
+  static constexpr const char *words[] = {
+      "lorem",      "ipsum",   "dolor",    "sit",       "amet",
+      "consectetur","adipiscing","elit",    "sed",       "do",
+      "eiusmod",    "tempor",  "incididunt","ut",       "labore",
+      "et",         "dolore",  "magna",    "aliqua",    "fusce",
+      "posuere",    "morbi",   "tempus",   "iaculis",   "urna",
+      "id",         "volutpat","lacus",    "laoreet",   "non",
+      "curabitur",  "gravida", "arcu",     "ac",        "tortor",
+      "dignissim"};
+  int word_count = random_integer(30, 60);
+  std::uniform_int_distribution<int> distribution(
+      0, sizeof(words) / sizeof(words[0]) - 1);
+  std::string result;
+  for (int i = 0; i < word_count; ++i) {
+    if (i > 0)
+      result += ' ';
+    result += words[distribution(rng())];
+  }
+  result += '.';
+  return result;
+}
+
+} // namespace astralix::testing


### PR DESCRIPTION
## Summary
- Add `remove_system<T>()` / `start_system<T>()` templates and `end()` virtual to ECS for runtime system lifecycle
- Add multithreaded job system with typed callable dispatch, priority queues, barriers, and main-thread drain
- Add `ASTRA_EXCEPTION_META` macro, `ExceptionMetadata` type, and MAGENTA log color
- Add granular `ASTRA_PROFILE_N` scopes across all init/start paths in Application
- Add mouse wheel delta accumulator to window events
- Replace `faker-cxx` submodule with `helpers/random` in arena allocator test