### PR TITLE
Add asset registry, render graph config, and manifest reload callbacks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,7 +63,7 @@ jobs:
             core.exportVariable('ACTIONS_RUNTIME_TOKEN', process.env.ACTIONS_RUNTIME_TOKEN || '');
 
       - name: Install vcpkg packages
-        run: ./vcpkg/vcpkg install --triplet x64-linux --x-install-root="${VCPKG_INSTALL_ROOT}"
+        run: ./vcpkg/vcpkg install --triplet x64-linux --x-feature=dev --x-install-root="${VCPKG_INSTALL_ROOT}"
 
       - name: Configure
         run: cmake --preset=debug -DASTRALIX_STREAMS_FORMATS=Json -DVCPKG_MANIFEST_INSTALL=OFF

--- a/.gitmodules
+++ b/.gitmodules
@@ -2,10 +2,6 @@
 	path = external/PhysX
 	url = https://github.com/NVIDIA-Omniverse/PhysX
   branch = main
-[submodule "external/faker-cxx"]
-	path = external/faker-cxx
-	url = https://github.com/cieslarmichal/faker-cxx
-	branch = main
 [submodule "external/imgui"]
 	path = external/imgui
 	url = https://github.com/LuizPedroSousa/imgui

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -194,6 +194,7 @@ add_subdirectory(src/shared/containers)
 if(NOT ASTRA_ENABLE_TESTS)
   add_subdirectory(src/shared/events)
   add_subdirectory(src/shared/ecs)
+  add_subdirectory(src/modules/jobs)
   add_subdirectory(src/modules/streams)
   add_subdirectory(src/modules/renderer/shader-lang)
   add_subdirectory(src/modules/project)
@@ -399,6 +400,7 @@ if(NOT ASTRA_ENABLE_TESTS)
           events
           ecs
           streams
+          jobs
           project
           window
           shader-lang

--- a/axgen/CMakeLists.txt
+++ b/axgen/CMakeLists.txt
@@ -14,10 +14,22 @@ list(FILTER AXGEN_SHADER_LANG_SRC EXCLUDE REGEX "\\.test\\.cpp$")
 set(AXGEN_STREAMS_SRC
   "${MODULES_DIR}/streams/context-proxy.cpp"
   "${MODULES_DIR}/streams/serialization-context.cpp"
-  "${MODULES_DIR}/streams/adapters/file/file-stream-reader.cpp")
+  "${MODULES_DIR}/streams/adapters/file/file-stream-reader.cpp"
+  "${MODULES_DIR}/streams/adapters/file/file-stream-writer.cpp")
+
+set(AXGEN_PROJECT_ASSET_SRC
+  "${MODULES_DIR}/project/assets/asset_graph.cpp"
+  "${MODULES_DIR}/project/assets/asset_cooker.cpp"
+  "${MODULES_DIR}/project/assets/pack_manifest.cpp")
+
+set(AXGEN_RENDERER_SUPPORT_SRC
+  "${MODULES_DIR}/renderer/importers/model-importer.cpp"
+  "${MODULES_DIR}/renderer/entities/serializers/axmesh-serializer.cpp"
+  "${MODULES_DIR}/renderer/resources/mesh.cpp")
 
 add_executable(axgen
   src/args.cpp
+  src/cook.cpp
   src/main.cpp
   src/project-bootstrap.cpp
   src/project-serializer.cpp
@@ -25,12 +37,15 @@ add_executable(axgen
   src/sync.cpp
   src/watch.cpp
   ${AXGEN_SHADER_LANG_SRC}
-  ${AXGEN_STREAMS_SRC})
+  ${AXGEN_STREAMS_SRC}
+  ${AXGEN_PROJECT_ASSET_SRC}
+  ${AXGEN_RENDERER_SUPPORT_SRC})
 
 target_include_directories(axgen PRIVATE
   "${CMAKE_CURRENT_SOURCE_DIR}/src"
   "${CMAKE_SOURCE_DIR}/src/modules/renderer"
   "${MODULES_DIR}"
+  "${MODULES_DIR}/project"
   "${MODULES_DIR}/streams"
   "${SHARED_DIR}/allocators"
   "${SHARED_DIR}/foundation"
@@ -43,6 +58,8 @@ target_compile_definitions(axgen PRIVATE
 target_link_libraries(axgen PRIVATE
   shared::allocators
   shared::foundation
+  assimp
+  mikktspace
   glm::glm)
 
 astralix_streams_enable_serialization_formats(axgen FORMATS

--- a/axgen/src/args.cpp
+++ b/axgen/src/args.cpp
@@ -38,12 +38,14 @@ bool parse(const std::vector<Token> &tokens, Options &opts) {
 
     if (token.kind == Token::Kind::Value) {
       if (!command_seen) {
-        if (token.text != "sync-shaders") {
+        if (token.text != "sync-shaders" && token.text != "cook-assets") {
           std::cerr << "error: unknown command '" << token.text << "'\n";
           return false;
         }
 
-        opts.command = Options::Command::SyncShaders;
+        opts.command = token.text == "sync-shaders"
+                           ? Options::Command::SyncShaders
+                           : Options::Command::CookAssets;
         command_seen = true;
         continue;
       }
@@ -90,6 +92,11 @@ bool parse(const std::vector<Token> &tokens, Options &opts) {
 
   if (!opts.help && opts.command == Options::Command::None) {
     std::cerr << "error: no command specified\n";
+    return false;
+  }
+
+  if (opts.command == Options::Command::CookAssets && opts.watch) {
+    std::cerr << "error: --watch is only supported by sync-shaders\n";
     return false;
   }
 

--- a/axgen/src/args.hpp
+++ b/axgen/src/args.hpp
@@ -7,7 +7,7 @@
 namespace axgen {
 
 struct Options {
-  enum class Command { None, SyncShaders };
+  enum class Command { None, SyncShaders, CookAssets };
 
   Command command = Command::None;
   std::string manifest_path;

--- a/axgen/src/args.test.cpp
+++ b/axgen/src/args.test.cpp
@@ -38,6 +38,12 @@ TEST(AxgenArgs, ParsesSyncShadersCommand) {
   EXPECT_EQ(options.command, Options::Command::SyncShaders);
 }
 
+TEST(AxgenArgs, ParsesCookAssetsCommand) {
+  Options options;
+  EXPECT_TRUE(parse(make_tokens({"cook-assets"}), options));
+  EXPECT_EQ(options.command, Options::Command::CookAssets);
+}
+
 TEST(AxgenArgs, ParsesManifestAndWatchFlags) {
   Options options;
   EXPECT_TRUE(parse(make_tokens(
@@ -80,6 +86,11 @@ TEST(AxgenArgs, ParsesRootFlag) {
 TEST(AxgenArgs, RejectsRootWithoutValue) {
   Options options;
   EXPECT_FALSE(parse(make_tokens({"sync-shaders", "--root"}), options));
+}
+
+TEST(AxgenArgs, RejectsWatchForCookAssets) {
+  Options options;
+  EXPECT_FALSE(parse(make_tokens({"cook-assets", "--watch"}), options));
 }
 
 } // namespace axgen

--- a/axgen/src/cook.cpp
+++ b/axgen/src/cook.cpp
@@ -1,0 +1,70 @@
+#include "cook.hpp"
+
+#include "project-locator.hpp"
+#include "project-serializer.hpp"
+#include "assets/asset_cooker.hpp"
+
+#include <filesystem>
+#include <iostream>
+#include <optional>
+
+namespace axgen {
+namespace {
+
+std::optional<std::filesystem::path> resolve_manifest(const Options &options,
+                                                      std::string *error) {
+  std::optional<std::filesystem::path> explicit_manifest;
+  if (!options.manifest_path.empty()) {
+    explicit_manifest = std::filesystem::path(options.manifest_path);
+  }
+
+  auto search_root = options.root_path.empty()
+                         ? std::filesystem::current_path()
+                         : std::filesystem::absolute(options.root_path);
+
+  return resolve_manifest_path(explicit_manifest, search_root, error);
+}
+
+} // namespace
+
+RunContext run_cook_once(const Options &options) {
+  RunContext context;
+
+  std::string manifest_error;
+  auto manifest_path = resolve_manifest(options, &manifest_error);
+  if (!manifest_path) {
+    std::cerr << "error: " << manifest_error << '\n';
+    return context;
+  }
+
+  std::string deserialize_error;
+  auto manifest =
+      ProjectSerializer::deserialize(*manifest_path, &deserialize_error);
+  if (!manifest) {
+    std::cerr << "error: " << deserialize_error << '\n';
+    return context;
+  }
+
+  astralix::AssetCooker cooker(astralix::AssetGraphConfig{
+      .project_root = manifest->project_root.lexically_normal(),
+      .project_resources_root =
+          (manifest->project_root / manifest->resources_directory)
+              .lexically_normal(),
+      .engine_assets_root =
+          std::filesystem::path(ASTRALIX_ENGINE_ASSETS_DIR).lexically_normal(),
+  });
+
+  const auto output_root =
+      (manifest->project_root / ".astralix" / "cooked").lexically_normal();
+  auto output = cooker.cook(manifest->asset_bindings, output_root);
+
+  std::cout << "axgen cook-assets: " << output.manifest.assets.size()
+            << " asset(s), " << output.cooked_artifact_count
+            << " cooked artifact(s), manifest "
+            << output.manifest_path.generic_string() << '\n';
+
+  context.ok = true;
+  return context;
+}
+
+} // namespace axgen

--- a/axgen/src/cook.hpp
+++ b/axgen/src/cook.hpp
@@ -1,0 +1,9 @@
+#pragma once
+
+#include "watch.hpp"
+
+namespace axgen {
+
+RunContext run_cook_once(const Options &options);
+
+} // namespace axgen

--- a/axgen/src/cook.test.cpp
+++ b/axgen/src/cook.test.cpp
@@ -1,0 +1,138 @@
+#include "cook.hpp"
+
+#include "args.hpp"
+#include "exceptions/base-exception.hpp"
+
+#include <gtest/gtest.h>
+
+#include <filesystem>
+#include <fstream>
+#include <sstream>
+
+namespace axgen {
+namespace {
+
+std::filesystem::path make_temp_root(const char *suffix) {
+  const auto root =
+      std::filesystem::temp_directory_path() / std::string(suffix);
+  std::filesystem::remove_all(root);
+  std::filesystem::create_directories(root);
+  return root;
+}
+
+void write_text(const std::filesystem::path &path, const std::string &text) {
+  std::filesystem::create_directories(path.parent_path());
+  std::ofstream out(path);
+  out << text;
+}
+
+void write_test_project(
+    const std::filesystem::path &root,
+    bool with_expected_material_slots
+) {
+  write_text(
+      root / "project.ax",
+      R"json({
+  "project": {
+    "resources": { "directory": "assets" },
+    "serialization": { "format": "json" }
+  },
+  "resources": [
+    {
+      "id": "models::triangle",
+      "asset": "models/triangle.axmodel"
+    }
+  ]
+})json"
+  );
+
+  write_text(
+      root / "assets" / "materials" / "triangle.axmaterial",
+      R"json({
+  "version": 1,
+  "textures": {}
+})json"
+  );
+
+  write_text(
+      root / "assets" / "models" / "triangle.axmodel",
+      with_expected_material_slots ? R"json({
+  "version": 1,
+  "source": "source/triangle.obj",
+  "materials": [
+    "../materials/triangle.axmaterial",
+    "../materials/triangle.axmaterial"
+  ]
+})json"
+                    : R"json({
+  "version": 1,
+  "source": "source/triangle.obj",
+  "materials": []
+})json"
+  );
+
+  write_text(
+      root / "assets" / "models" / "source" / "triangle.obj",
+      R"obj(mtllib triangle.mtl
+o Triangle
+v 0.0 0.0 0.0
+v 1.0 0.0 0.0
+v 0.0 1.0 0.0
+vt 0.0 0.0
+vt 1.0 0.0
+vt 0.0 1.0
+vn 0.0 0.0 1.0
+usemtl default
+f 1/1/1 2/2/1 3/3/1
+)obj"
+  );
+  write_text(
+      root / "assets" / "models" / "source" / "triangle.mtl",
+      "newmtl default\nKd 1.0 1.0 1.0\n"
+  );
+}
+
+TEST(AxgenCook, GeneratesPackManifestAndAxmeshArtifact) {
+  const auto root = make_temp_root("astralix-axgen-cook");
+  write_test_project(root, true);
+
+  Options options;
+  options.command = Options::Command::CookAssets;
+  options.root_path = root.string();
+
+  const auto result = run_cook_once(options);
+  ASSERT_TRUE(result.ok);
+
+  const auto manifest_path = root / ".astralix" / "cooked" / "pack.axpack";
+  ASSERT_TRUE(std::filesystem::exists(manifest_path));
+
+  std::ifstream manifest_stream(manifest_path);
+  std::stringstream manifest_buffer;
+  manifest_buffer << manifest_stream.rdbuf();
+  const auto manifest_text = manifest_buffer.str();
+  EXPECT_NE(manifest_text.find("models::triangle"), std::string::npos);
+  EXPECT_NE(manifest_text.find(".axmesh"), std::string::npos);
+
+  size_t axmesh_count = 0;
+  for (const auto &entry : std::filesystem::directory_iterator(
+           root / ".astralix" / "cooked" / "artifacts" / "models")) {
+    if (entry.path().extension() == ".axmesh") {
+      ++axmesh_count;
+    }
+  }
+  EXPECT_EQ(axmesh_count, 1u);
+}
+
+TEST(AxgenCook, RejectsModelWhenMaterialSlotsAreMissing) {
+  const auto root = make_temp_root("astralix-axgen-cook-mismatch");
+  write_test_project(root, false);
+
+  Options options;
+  options.command = Options::Command::CookAssets;
+  options.root_path = root.string();
+
+  EXPECT_THROW(run_cook_once(options), astralix::BaseException);
+}
+
+} // namespace
+} // namespace axgen

--- a/axgen/src/main.cpp
+++ b/axgen/src/main.cpp
@@ -1,4 +1,5 @@
 #include "args.hpp"
+#include "cook.hpp"
 #include "project-bootstrap.hpp"
 #include "project-locator.hpp"
 #include "shader-lang/compiler.hpp"
@@ -17,6 +18,8 @@ void print_usage(const char *prog) {
   std::cout << "Usage:\n"
             << "  " << prog
             << " sync-shaders [--manifest <path>] [--root <dir>] [--watch]\n"
+            << "  " << prog
+            << " cook-assets [--manifest <path>] [--root <dir>]\n"
             << "  " << prog << " --help\n";
 }
 
@@ -116,11 +119,22 @@ int main(int argc, char **argv) {
   }
 
   try {
-    if (options.watch) {
+    if (options.command == axgen::Options::Command::SyncShaders &&
+        options.watch) {
       return axgen::run_watch_loop(options, axgen::run_sync_once);
     }
 
-    return axgen::run_sync_once(options).ok ? 0 : 1;
+    switch (options.command) {
+    case axgen::Options::Command::SyncShaders:
+      return axgen::run_sync_once(options).ok ? 0 : 1;
+    case axgen::Options::Command::CookAssets:
+      return axgen::run_cook_once(options).ok ? 0 : 1;
+    case axgen::Options::Command::None:
+      break;
+    }
+
+    std::cerr << "error: no command specified\n";
+    return 1;
   } catch (const std::exception &error) {
     std::cerr << "error: " << error.what() << '\n';
     return 1;

--- a/axgen/src/project-bootstrap.cpp
+++ b/axgen/src/project-bootstrap.cpp
@@ -97,7 +97,8 @@ discover_project_shaders(const std::filesystem::path &manifest_path,
   for (const auto &descriptor : manifest->shaders) {
     if (!collect_shader(descriptor.vertex_path) ||
         !collect_shader(descriptor.fragment_path) ||
-        !collect_shader(descriptor.geometry_path)) {
+        !collect_shader(descriptor.geometry_path) ||
+        !collect_shader(descriptor.compute_path)) {
       return std::nullopt;
     }
   }

--- a/axgen/src/project-serializer.cpp
+++ b/axgen/src/project-serializer.cpp
@@ -176,6 +176,21 @@ std::optional<ManifestPath> parse_path(ContextProxy ctx, std::string *error) {
   return parsed_path;
 }
 
+bool has_inline_resource_fields(ContextProxy &asset) {
+  return asset["type"].kind() == SerializationTypeKind::String ||
+         asset["path"].kind() == SerializationTypeKind::String ||
+         asset["vertex"].kind() == SerializationTypeKind::String ||
+         asset["fragment"].kind() == SerializationTypeKind::String ||
+         asset["compute"].kind() == SerializationTypeKind::String ||
+         asset["geometry"].kind() == SerializationTypeKind::String ||
+         asset["faces"].kind() == SerializationTypeKind::Array ||
+         asset["textures"].kind() == SerializationTypeKind::Object;
+}
+
+bool is_asset_binding_entry(ContextProxy &asset) {
+  return asset["asset"].kind() == SerializationTypeKind::String;
+}
+
 } // namespace
 
 std::optional<ProjectManifest>
@@ -205,6 +220,28 @@ ProjectSerializer::deserialize(const std::filesystem::path &manifest_path,
   manifest.resources_directory =
       (*ctx)["project"]["resources"]["directory"].as<std::string>();
 
+  const auto declared_project_directory =
+      (*ctx)["project"]["directory"].as<std::string>();
+  if (!declared_project_directory.empty()) {
+    const auto declared_path = std::filesystem::path(declared_project_directory);
+    manifest.project_root =
+        declared_path.is_absolute()
+            ? declared_path.lexically_normal()
+            : (normalized_manifest.parent_path() / declared_path)
+                  .lexically_normal();
+  } else if (!manifest.resources_directory.empty()) {
+    const auto direct_resources_root =
+        (manifest.project_root / manifest.resources_directory).lexically_normal();
+    const auto parent_resources_root =
+        (manifest.project_root.parent_path() / manifest.resources_directory)
+            .lexically_normal();
+
+    if (!std::filesystem::exists(direct_resources_root) &&
+        std::filesystem::exists(parent_resources_root)) {
+      manifest.project_root = manifest.project_root.parent_path().lexically_normal();
+    }
+  }
+
   const auto declared_format =
       (*ctx)["project"]["serialization"]["format"].as<std::string>();
   if (!declared_format.empty()) {
@@ -226,9 +263,36 @@ ProjectSerializer::deserialize(const std::filesystem::path &manifest_path,
   auto resources = (*ctx)["resources"];
   const auto resource_count = resources.size();
   manifest.shaders.reserve(resource_count);
+  manifest.asset_bindings.reserve(resource_count);
 
   for (size_t i = 0; i < resource_count; ++i) {
     auto asset = resources[static_cast<int>(i)];
+
+    const bool asset_binding = is_asset_binding_entry(asset);
+    const bool inline_resource = has_inline_resource_fields(asset);
+
+    if (asset_binding && inline_resource) {
+      set_error(error, "resource entry mixes inline fields with an asset binding");
+      return std::nullopt;
+    }
+
+    if (asset_binding) {
+      const auto id = asset["id"].as<std::string>();
+      const auto asset_path = asset["asset"].as<std::string>();
+      if (id.empty()) {
+        set_error(error, "asset binding id is required");
+        return std::nullopt;
+      }
+      if (asset_path.empty()) {
+        set_error(error, "asset binding path is required for '" + id + "'");
+        return std::nullopt;
+      }
+
+      manifest.asset_bindings.push_back(
+          astralix::AssetBindingConfig{.id = id, .asset_path = asset_path}
+      );
+    }
+
     if (asset["type"].as<std::string>() != "Shader") {
       continue;
     }
@@ -256,6 +320,14 @@ ProjectSerializer::deserialize(const std::filesystem::path &manifest_path,
     descriptor.geometry_path = parse_path(asset["geometry"], &path_error);
     if (!path_error.empty()) {
       set_error(error, "invalid geometry path for shader '" + shader_id +
+                           "': " + path_error);
+      return std::nullopt;
+    }
+
+    path_error.clear();
+    descriptor.compute_path = parse_path(asset["compute"], &path_error);
+    if (!path_error.empty()) {
+      set_error(error, "invalid compute path for shader '" + shader_id +
                            "': " + path_error);
       return std::nullopt;
     }

--- a/axgen/src/project-serializer.hpp
+++ b/axgen/src/project-serializer.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "assets/asset_binding.hpp"
 #include "serialization-context.hpp"
 
 #include <cstdint>
@@ -21,6 +22,7 @@ struct ShaderDescriptorInput {
   std::optional<ManifestPath> vertex_path;
   std::optional<ManifestPath> fragment_path;
   std::optional<ManifestPath> geometry_path;
+  std::optional<ManifestPath> compute_path;
 };
 
 struct ProjectManifest {
@@ -30,6 +32,7 @@ struct ProjectManifest {
   astralix::SerializationFormat serialization_format =
       astralix::SerializationFormat::Json;
   std::vector<ShaderDescriptorInput> shaders;
+  std::vector<astralix::AssetBindingConfig> asset_bindings;
 };
 
 class ProjectSerializer {

--- a/axgen/src/project-serializer.test.cpp
+++ b/axgen/src/project-serializer.test.cpp
@@ -1,0 +1,121 @@
+#include "project-serializer.hpp"
+
+#include <gtest/gtest.h>
+
+#include <filesystem>
+#include <fstream>
+
+namespace axgen {
+namespace {
+
+std::filesystem::path make_temp_root(const char *suffix) {
+  const auto root =
+      std::filesystem::temp_directory_path() / std::string(suffix);
+  std::filesystem::remove_all(root);
+  std::filesystem::create_directories(root);
+  return root;
+}
+
+void write_text(const std::filesystem::path &path, const std::string &text) {
+  std::filesystem::create_directories(path.parent_path());
+  std::ofstream out(path);
+  out << text;
+}
+
+TEST(ProjectSerializerTest, ParsesAssetBindingsAlongsideShaders) {
+  const auto root = make_temp_root("astralix-axgen-project-serializer");
+  const auto manifest_path = root / "project.ax";
+
+  write_text(
+      manifest_path,
+      R"json({
+  "project": {
+    "resources": { "directory": "assets" },
+    "serialization": { "format": "json" }
+  },
+  "resources": [
+    {
+      "id": "materials::brick",
+      "asset": "materials/brick.axmaterial"
+    },
+    {
+      "id": "shaders::main",
+      "type": "Shader",
+      "vertex": "@engine/shaders/post-process.axsl",
+      "fragment": "shaders/local.axsl"
+    }
+  ]
+})json"
+  );
+
+  std::string error;
+  const auto manifest = ProjectSerializer::deserialize(manifest_path, &error);
+  ASSERT_TRUE(manifest.has_value()) << error;
+  ASSERT_EQ(manifest->asset_bindings.size(), 1u);
+  EXPECT_EQ(manifest->asset_bindings[0].id, "materials::brick");
+  EXPECT_EQ(manifest->asset_bindings[0].asset_path, "materials/brick.axmaterial");
+  ASSERT_EQ(manifest->shaders.size(), 1u);
+  ASSERT_TRUE(manifest->shaders[0].vertex_path.has_value());
+  ASSERT_TRUE(manifest->shaders[0].fragment_path.has_value());
+}
+
+TEST(ProjectSerializerTest, ParsesComputeOnlyShaders) {
+  const auto root = make_temp_root("astralix-axgen-project-serializer-compute");
+  const auto manifest_path = root / "project.ax";
+
+  write_text(
+      manifest_path,
+      R"json({
+  "project": {
+    "resources": { "directory": "assets" },
+    "serialization": { "format": "json" }
+  },
+  "resources": [
+    {
+      "id": "shaders::histogram",
+      "type": "Shader",
+      "compute": "@engine/shaders/eye-adaptation-histogram.axsl"
+    }
+  ]
+})json"
+  );
+
+  std::string error;
+  const auto manifest = ProjectSerializer::deserialize(manifest_path, &error);
+  ASSERT_TRUE(manifest.has_value()) << error;
+  ASSERT_EQ(manifest->shaders.size(), 1u);
+  EXPECT_FALSE(manifest->shaders[0].vertex_path.has_value());
+  EXPECT_FALSE(manifest->shaders[0].fragment_path.has_value());
+  ASSERT_TRUE(manifest->shaders[0].compute_path.has_value());
+}
+
+TEST(ProjectSerializerTest, RejectsMixedInlineAndAssetEntries) {
+  const auto root = make_temp_root("astralix-axgen-project-serializer-mixed");
+  const auto manifest_path = root / "project.ax";
+
+  write_text(
+      manifest_path,
+      R"json({
+  "project": {
+    "resources": { "directory": "assets" },
+    "serialization": { "format": "json" }
+  },
+  "resources": [
+    {
+      "id": "materials::brick",
+      "type": "Material",
+      "asset": "materials/brick.axmaterial"
+    }
+  ]
+})json"
+  );
+
+  std::string error;
+  const auto manifest = ProjectSerializer::deserialize(manifest_path, &error);
+  EXPECT_FALSE(manifest.has_value());
+  EXPECT_NE(error.find("mixes inline fields with an asset binding"),
+            std::string::npos);
+}
+
+} // namespace
+} // namespace axgen

--- a/src/modules/application/CMakeLists.txt
+++ b/src/modules/application/CMakeLists.txt
@@ -2,6 +2,9 @@
 file(GLOB_RECURSE APPLICATION_SRC ${CMAKE_CURRENT_SOURCE_DIR}/*.cpp)
 file(GLOB_RECURSE APPLICATION_HEADER ${CMAKE_CURRENT_SOURCE_DIR}/*.hpp)
 
+list(FILTER APPLICATION_SRC EXCLUDE REGEX ".*\\.test\\.cpp$")
+list(FILTER APPLICATION_HEADER EXCLUDE REGEX ".*\\.test\\.hpp$")
+
 add_library(application STATIC ${APPLICATION_SRC} ${APPLICATION_HEADER})
 
 include_directories(${CMAKE_SOURCE_DIR}/external)
@@ -17,7 +20,17 @@ target_link_libraries(
   PUBLIC
   glad::glad
   project
+  jobs
   engine window shared::foundation
 )
+
+if(ASTRA_RENDERER_HOT_RELOAD)
+  target_compile_definitions(application PRIVATE
+    ASTRA_RENDERER_HOT_RELOAD
+    ASTRA_RENDER_PASSES_MODULE_PATH="${CMAKE_BINARY_DIR}/hotreload/librender_passes_live.so"
+    ASTRA_RENDER_PASSES_SOURCE_DIR="${PROJECT_SOURCE_DIR}/src/modules/renderer"
+    ASTRA_RENDER_PASSES_BUILD_DIR="${CMAKE_BINARY_DIR}"
+  )
+endif()
 
 source_group(TREE "${CMAKE_CURRENT_SOURCE_DIR}" FILES ${APPLICATION_SOURCES} ${APPLICATION_HEADERS})

--- a/src/modules/application/application.cpp
+++ b/src/modules/application/application.cpp
@@ -7,25 +7,62 @@
 #include "managers/project-manager.hpp"
 #include "managers/system-manager.hpp"
 #include "managers/window-manager.hpp"
+#include "systems/job-system/job-system.hpp"
 #include "time.hpp"
 #include "trace.hpp"
+#if defined(ASTRA_RENDERER_HOT_RELOAD)
+#include "module-handle.hpp"
+#include "systems/render-system/render-system.hpp"
+#endif
 
 namespace astralix {
+
+namespace {
+
+constexpr size_t k_main_thread_job_drain_budget = 2u;
+
+} // namespace
+
 Application *Application::m_instance = nullptr;
 
 Application *Application::init() {
   ASTRA_PROFILE_N("Application::init");
   m_instance = new Application;
 
-  EventDispatcher::init();
-  EventScheduler::init();
-  Time::init();
-  ConsoleManager::get();
-  ProjectManager::init();
-  Engine::init();
-  SystemManager::init();
-  WindowManager::init();
+  {
+    ASTRA_PROFILE_N("EventDispatcher::init");
+    EventDispatcher::init();
+  }
+  {
+    ASTRA_PROFILE_N("EventScheduler::init");
+    EventScheduler::init();
+  }
+  {
+    ASTRA_PROFILE_N("Time::init");
+    Time::init();
+  }
+  {
+    ASTRA_PROFILE_N("ConsoleManager::init");
+    ConsoleManager::get();
+  }
+  {
+    ASTRA_PROFILE_N("ProjectManager::init");
+    ProjectManager::init();
+  }
+  {
+    ASTRA_PROFILE_N("Engine::init");
+    Engine::init();
+  }
+  {
+    ASTRA_PROFILE_N("SystemManager::init");
+    SystemManager::init();
+  }
+  {
+    ASTRA_PROFILE_N("WindowManager::init");
+    WindowManager::init();
+  }
   if (ApplicationPluginRegistry::get() == nullptr) {
+    ASTRA_PROFILE_N("ApplicationPluginRegistry::init");
     ApplicationPluginRegistry::init();
   }
 
@@ -34,16 +71,28 @@ Application *Application::init() {
 
 void Application::start() {
   ASTRA_PROFILE_N("Application::start");
-  WindowManager::get()->start();
-  Engine::get()->start();
+  {
+    ASTRA_PROFILE_N("WindowManager::start");
+    WindowManager::get()->start();
+  }
+  {
+    ASTRA_PROFILE_N("Engine::start");
+    Engine::get()->start();
+  }
 
-  ApplicationPluginContext plugin_context{
-      .project = active_project(),
-      .systems = SystemManager::get(),
-  };
-  application_plugin_registry()->apply_plugins(plugin_context);
+  {
+    ASTRA_PROFILE_N("ApplicationPluginRegistry::apply_plugins");
+    ApplicationPluginContext plugin_context{
+        .project = active_project(),
+        .systems = SystemManager::get(),
+    };
+    application_plugin_registry()->apply_plugins(plugin_context);
+  }
 
-  SystemManager::get()->start();
+  {
+    ASTRA_PROFILE_N("SystemManager::start");
+    SystemManager::get()->start();
+  }
 }
 
 void Application::run() {
@@ -54,7 +103,38 @@ void Application::run() {
 
   auto scheduler = EventScheduler::get();
 
+#if defined(ASTRA_RENDERER_HOT_RELOAD)
+  ModuleHandle render_passes_module(ModuleHandle::Config{
+      .module_path = ASTRA_RENDER_PASSES_MODULE_PATH,
+      .source_dir = ASTRA_RENDER_PASSES_SOURCE_DIR,
+      .build_dir = ASTRA_RENDER_PASSES_BUILD_DIR,
+      .build_target = "render_passes_live",
+  });
+  {
+    ASTRA_PROFILE_N("RenderPassesLoader::initial_load");
+    if (render_passes_module.load()) {
+      auto *render_system = SystemManager::get()->get_system<RenderSystem>();
+      if (render_system != nullptr) {
+        render_system->load_passes_from_module(render_passes_module.api());
+      }
+    }
+  }
+#endif
+
   while (wm->is_open()) {
+    if (m_pre_frame_callback) m_pre_frame_callback();
+#if defined(ASTRA_RENDERER_HOT_RELOAD)
+    if (render_passes_module.poll_changed()) {
+      auto *render_system = system->get_system<RenderSystem>();
+      if (render_system != nullptr) {
+        render_system->prepare_for_pass_reload();
+      }
+      render_passes_module.api()->unload();
+      if (render_passes_module.load() && render_system != nullptr) {
+        render_system->load_passes_from_module(render_passes_module.api());
+      }
+    }
+#endif
     ASTRA_FRAME_MARK;
     ASTRA_PROFILE_N("Application::frame");
     time->update();
@@ -66,8 +146,20 @@ void Application::run() {
       ASTRA_PROFILE_N("EventScheduler::POST_FRAME");
       scheduler->bind(SchedulerType::POST_FRAME);
     }
+    {
+      ASTRA_PROFILE_N("JobSystem::drain_main_queue_pre_update");
+      if (auto *jobs = JobSystem::get(); jobs != nullptr) {
+        jobs->drain_main_queue(k_main_thread_job_drain_budget);
+      }
+    }
     system->fixed_update(1 / 60.0f);
     system->update(Time::get()->get_deltatime());
+    {
+      ASTRA_PROFILE_N("JobSystem::drain_main_queue_post_update");
+      if (auto *jobs = JobSystem::get(); jobs != nullptr) {
+        jobs->drain_main_queue(k_main_thread_job_drain_budget);
+      }
+    }
     {
       ASTRA_PROFILE_N("EventScheduler::IMMEDIATE");
       scheduler->bind(SchedulerType::IMMEDIATE);
@@ -84,6 +176,9 @@ void Application::run() {
 void Application::end() { delete m_instance; }
 
 Application::~Application() {
+  if (auto system_manager = SystemManager::get(); system_manager != nullptr) {
+    system_manager->remove_system<JobSystem>();
+  }
   Engine::get()->end();
   Time::get()->end();
   WindowManager::get()->end();

--- a/src/modules/application/application.hpp
+++ b/src/modules/application/application.hpp
@@ -1,12 +1,20 @@
 #pragma once
 
+#include <functional>
+
 namespace astralix {
 class Application {
 
 public:
+  using PreFrameCallback = std::function<void()>;
+
   static Application *init();
   void start();
   void run();
+
+  void set_pre_frame_callback(PreFrameCallback callback) {
+    m_pre_frame_callback = std::move(callback);
+  }
 
   static Application *get() { return m_instance; }
   static void end();
@@ -16,6 +24,7 @@ private:
   ~Application();
 
   static Application *m_instance;
+  PreFrameCallback m_pre_frame_callback;
 };
 
 } // namespace astralix

--- a/src/modules/jobs/CMakeLists.txt
+++ b/src/modules/jobs/CMakeLists.txt
@@ -1,0 +1,22 @@
+file(GLOB_RECURSE JOB_SRC ${CMAKE_CURRENT_SOURCE_DIR}/*.cpp)
+file(GLOB_RECURSE JOB_HEADERS ${CMAKE_CURRENT_SOURCE_DIR}/*.hpp)
+
+list(FILTER JOB_SRC EXCLUDE REGEX ".*\\.test\\.cpp$")
+list(FILTER JOB_HEADERS EXCLUDE REGEX ".*\\.test\\.hpp$")
+
+add_library(jobs STATIC ${JOB_SRC} ${JOB_HEADERS})
+
+target_include_directories(jobs
+  PUBLIC
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
+    $<INSTALL_INTERFACE:include/astralix/modules/jobs>
+)
+
+target_link_libraries(
+  jobs
+  PUBLIC
+  shared::ecs
+  shared::foundation
+)
+
+source_group(TREE "${CMAKE_CURRENT_SOURCE_DIR}" FILES ${JOB_SRC} ${JOB_HEADERS})

--- a/src/modules/jobs/systems/job-system/execution-policy.hpp
+++ b/src/modules/jobs/systems/job-system/execution-policy.hpp
@@ -1,0 +1,24 @@
+#pragma once
+
+#include <cstdint>
+
+namespace astralix::terrain {
+
+enum class ExecutionTrigger : uint8_t {
+  OneShot,
+  PerFrame,
+  OnDemand,
+};
+
+enum class QueueHint : uint8_t {
+  Main,
+  AsyncCompute,
+  Background,
+};
+
+struct ExecutionPolicy {
+  ExecutionTrigger trigger = ExecutionTrigger::OneShot;
+  QueueHint queue_hint = QueueHint::Main;
+};
+
+} // namespace astralix::terrain

--- a/src/modules/jobs/systems/job-system/job-callable.cpp
+++ b/src/modules/jobs/systems/job-system/job-callable.cpp
@@ -1,0 +1,1 @@
+#include "job-callable.hpp"

--- a/src/modules/jobs/systems/job-system/job-callable.hpp
+++ b/src/modules/jobs/systems/job-system/job-callable.hpp
@@ -1,0 +1,137 @@
+#pragma once
+
+#include <cstddef>
+#include <new>
+#include <type_traits>
+#include <utility>
+
+namespace astralix {
+
+class JobCallable {
+public:
+  static constexpr size_t INLINE_CAPACITY = 56u;
+
+  JobCallable() noexcept = default;
+
+  template <typename F>
+    requires(!std::is_same_v<std::decay_t<F>, JobCallable> &&
+             std::is_invocable_v<F>)
+  JobCallable(F &&callable) {
+    construct(std::forward<F>(callable));
+  }
+
+  ~JobCallable() { destroy(); }
+
+  JobCallable(JobCallable &&other) noexcept {
+    if (other.m_ops != nullptr) {
+      other.m_ops->move_into(other.m_storage, m_storage);
+      m_ops = other.m_ops;
+      other.m_ops = nullptr;
+    }
+  }
+
+  JobCallable &operator=(JobCallable &&other) noexcept {
+    if (this == &other) {
+      return *this;
+    }
+
+    destroy();
+
+    if (other.m_ops != nullptr) {
+      other.m_ops->move_into(other.m_storage, m_storage);
+      m_ops = other.m_ops;
+      other.m_ops = nullptr;
+    }
+
+    return *this;
+  }
+
+  JobCallable(const JobCallable &) = delete;
+  JobCallable &operator=(const JobCallable &) = delete;
+
+  void operator()() {
+    if (m_ops != nullptr) {
+      m_ops->invoke(m_storage);
+    }
+  }
+
+  explicit operator bool() const noexcept { return m_ops != nullptr; }
+
+private:
+  struct Ops {
+    void (*invoke)(void *storage);
+    void (*move_into)(void *source, void *destination);
+    void (*destroy)(void *storage);
+  };
+
+  template <typename F, bool Inline>
+  static const Ops &ops_for() {
+    static const Ops ops{
+        .invoke =
+            [](void *storage) {
+              if constexpr (Inline) {
+                (*static_cast<F *>(storage))();
+              } else {
+                (*(*static_cast<F **>(storage)))();
+              }
+            },
+        .move_into =
+            [](void *source, void *destination) {
+              if constexpr (Inline) {
+                auto *source_value = static_cast<F *>(source);
+                ::new (destination) F(std::move(*source_value));
+                source_value->~F();
+              } else {
+                *static_cast<F **>(destination) = *static_cast<F **>(source);
+                *static_cast<F **>(source) = nullptr;
+              }
+            },
+        .destroy =
+            [](void *storage) {
+              if constexpr (Inline) {
+                static_cast<F *>(storage)->~F();
+              } else {
+                F *pointer = *static_cast<F **>(storage);
+                if (pointer != nullptr) {
+                  pointer->~F();
+                  ::operator delete(pointer);
+                }
+              }
+            },
+    };
+
+    return ops;
+  }
+
+  template <typename F>
+  void construct(F &&callable) {
+    using Decayed = std::decay_t<F>;
+
+    constexpr bool fits_inline =
+        sizeof(Decayed) <= INLINE_CAPACITY &&
+        alignof(Decayed) <= alignof(std::max_align_t) &&
+        std::is_nothrow_move_constructible_v<Decayed>;
+
+    if constexpr (fits_inline) {
+      ::new (m_storage) Decayed(std::forward<F>(callable));
+      m_ops = &ops_for<Decayed, true>();
+    } else {
+      auto *heap_value = static_cast<Decayed *>(::operator new(sizeof(Decayed)));
+      ::new (heap_value) Decayed(std::forward<F>(callable));
+      *reinterpret_cast<Decayed **>(m_storage) = heap_value;
+      m_ops = &ops_for<Decayed, false>();
+    }
+  }
+
+  void destroy() noexcept {
+    if (m_ops != nullptr) {
+      m_ops->destroy(m_storage);
+      m_ops = nullptr;
+    }
+  }
+
+  alignas(std::max_align_t) unsigned char m_storage[INLINE_CAPACITY]{};
+  const Ops *m_ops = nullptr;
+};
+
+} // namespace astralix

--- a/src/modules/jobs/systems/job-system/job-system.cpp
+++ b/src/modules/jobs/systems/job-system/job-system.cpp
@@ -1,0 +1,732 @@
+#include "job-system.hpp"
+
+#include "assert.hpp"
+#include "log.hpp"
+
+#include <algorithm>
+#include <array>
+#include <chrono>
+#include <condition_variable>
+#include <deque>
+#include <exception>
+#include <mutex>
+#include <thread>
+#include <unordered_map>
+#include <utility>
+#include <vector>
+
+namespace astralix {
+
+namespace {
+
+constexpr std::array<JobPriority, 4> k_priority_order = {
+    JobPriority::Critical,
+    JobPriority::High,
+    JobPriority::Normal,
+    JobPriority::Low,
+};
+
+const char *queue_name(JobQueue queue) {
+  switch (queue) {
+    case JobQueue::Worker:
+      return "Worker";
+    case JobQueue::Main:
+      return "Main";
+    case JobQueue::Background:
+      return "Background";
+  }
+
+  return "Unknown";
+}
+
+const char *priority_name(JobPriority priority) {
+  switch (priority) {
+    case JobPriority::Low:
+      return "Low";
+    case JobPriority::Normal:
+      return "Normal";
+    case JobPriority::High:
+      return "High";
+    case JobPriority::Critical:
+      return "Critical";
+  }
+
+  return "Unknown";
+}
+
+size_t priority_index(JobPriority priority) {
+  switch (priority) {
+    case JobPriority::Low:
+      return 0u;
+    case JobPriority::Normal:
+      return 1u;
+    case JobPriority::High:
+      return 2u;
+    case JobPriority::Critical:
+      return 3u;
+  }
+
+  return 1u;
+}
+
+class JobSystemImpl {
+public:
+  explicit JobSystemImpl(JobSystem::Config config)
+      : m_main_thread_id(std::this_thread::get_id()) {
+    uint32_t worker_count = config.worker_count;
+    if (worker_count == 0u) {
+      const uint32_t hardware_threads = std::thread::hardware_concurrency();
+      worker_count = hardware_threads > 1u ? hardware_threads - 1u : 1u;
+    }
+
+    m_worker_threads.reserve(worker_count);
+    for (uint32_t index = 0; index < worker_count; ++index) {
+      m_worker_threads.emplace_back([this]() { worker_loop(); });
+    }
+
+    LOG_INFO("[JobSystem] initialized", "workers=", worker_count);
+  }
+
+  ~JobSystemImpl() = default;
+
+  JobHandle submit(
+      JobCallable work,
+      JobQueue queue,
+      JobPriority priority
+  ) {
+    return submit_locked({}, JobBarrier{}, std::move(work), queue, priority);
+  }
+
+  JobHandle submit_after(
+      std::span<const JobHandle> dependencies,
+      JobCallable work,
+      JobQueue queue,
+      JobPriority priority
+  ) {
+    return submit_locked(
+        dependencies, JobBarrier{}, std::move(work), queue, priority
+    );
+  }
+
+  JobHandle submit_after_barrier(
+      JobBarrier barrier,
+      JobCallable work,
+      JobQueue queue,
+      JobPriority priority
+  ) {
+    return submit_locked({}, barrier, std::move(work), queue, priority);
+  }
+
+  JobBarrier create_barrier(uint32_t expected_count) {
+    std::lock_guard lock(m_mutex);
+
+    JobBarrier barrier{.id = m_next_barrier_id++};
+    auto &record = m_barriers[barrier.id];
+    record.remaining = expected_count;
+    record.fired = expected_count == 0u;
+    LOG_DEBUG(
+        "[JobSystem] created barrier",
+        "barrier_id=", barrier.id,
+        "expected_count=", expected_count
+    );
+    return barrier;
+  }
+
+  void attach_to_barrier(JobHandle handle, JobBarrier barrier) {
+    if (!handle.is_valid() || !barrier.is_valid()) {
+      return;
+    }
+
+    std::lock_guard lock(m_mutex);
+
+    auto job_it = m_jobs.find(handle.id);
+    ASTRA_ENSURE(job_it == m_jobs.end(), "Unknown job handle");
+
+    auto barrier_it = m_barriers.find(barrier.id);
+    ASTRA_ENSURE(barrier_it == m_barriers.end(), "Unknown job barrier");
+
+    if (barrier_it->second.fired) {
+      return;
+    }
+
+    auto &job = job_it->second;
+    if (job.complete) {
+      complete_barrier_attachment_locked(barrier.id);
+      return;
+    }
+
+    if (std::find(
+            job.attached_barriers.begin(),
+            job.attached_barriers.end(),
+            barrier.id
+        ) != job.attached_barriers.end()) {
+      return;
+    }
+
+    job.attached_barriers.push_back(barrier.id);
+    LOG_DEBUG(
+        "[JobSystem] attached job to barrier",
+        "job_id=", handle.id,
+        "barrier_id=", barrier.id
+    );
+  }
+
+  bool is_complete(JobHandle handle) const {
+    if (!handle.is_valid()) {
+      return true;
+    }
+
+    std::lock_guard lock(m_mutex);
+
+    auto it = m_jobs.find(handle.id);
+    ASTRA_ENSURE(it == m_jobs.end(), "Unknown job handle");
+    return it->second.complete;
+  }
+
+  void wait(JobHandle handle) {
+    if (!handle.is_valid()) {
+      return;
+    }
+
+    for (;;) {
+      {
+        std::lock_guard lock(m_mutex);
+        auto it = m_jobs.find(handle.id);
+        ASTRA_ENSURE(it == m_jobs.end(), "Unknown job handle");
+        if (it->second.complete) {
+          if (it->second.exception != nullptr) {
+            std::rethrow_exception(it->second.exception);
+          }
+          return;
+        }
+      }
+
+      if (is_main_thread() && drain_main_queue(1u) > 0u) {
+        continue;
+      }
+
+      std::unique_lock lock(m_mutex);
+      m_completion_cv.wait_for(lock, std::chrono::milliseconds(1));
+    }
+  }
+
+  void wait_all(std::span<const JobHandle> handles) {
+    for (const auto &handle : handles) {
+      wait(handle);
+    }
+  }
+
+  void wait_barrier(JobBarrier barrier) {
+    if (!barrier.is_valid()) {
+      return;
+    }
+
+    for (;;) {
+      {
+        std::lock_guard lock(m_mutex);
+        auto it = m_barriers.find(barrier.id);
+        ASTRA_ENSURE(it == m_barriers.end(), "Unknown job barrier");
+        if (it->second.fired) {
+          return;
+        }
+      }
+
+      if (is_main_thread() && drain_main_queue(1u) > 0u) {
+        continue;
+      }
+
+      std::unique_lock lock(m_mutex);
+      m_completion_cv.wait_for(lock, std::chrono::milliseconds(1));
+    }
+  }
+
+  size_t drain_main_queue(size_t max_jobs) {
+    ASTRA_ENSURE(
+        !is_main_thread(),
+        "Main queue jobs must be drained from the initializing thread"
+    );
+
+    size_t drained = 0u;
+
+    while (drained < max_jobs) {
+      JobCallable work;
+      uint64_t job_id = 0u;
+
+      {
+        std::lock_guard lock(m_mutex);
+        job_id = pop_ready_job_locked(m_main_ready);
+        if (job_id == 0u) {
+          break;
+        }
+
+        auto &job = m_jobs.at(job_id);
+        job.queued = false;
+        job.running = true;
+        ++m_running_jobs;
+        work = std::move(job.work);
+      }
+
+      execute_job(job_id, std::move(work));
+      ++drained;
+    }
+
+    if (drained > 0u) {
+      LOG_DEBUG("[JobSystem] drained main queue", "jobs=", drained);
+    }
+
+    return drained;
+  }
+
+  bool has_pending_main_work() const {
+    std::lock_guard lock(m_mutex);
+    return !m_main_ready.empty();
+  }
+
+  void shutdown() {
+    wait_for_quiescence();
+
+    {
+      std::lock_guard lock(m_mutex);
+      m_stopping = true;
+    }
+
+    m_ready_cv.notify_all();
+
+    for (auto &worker : m_worker_threads) {
+      if (worker.joinable()) {
+        worker.join();
+      }
+    }
+
+    LOG_INFO("[JobSystem] shutdown complete");
+  }
+
+private:
+  struct ReadyQueues {
+    std::array<std::deque<uint64_t>, 4> by_priority;
+
+    bool empty() const {
+      for (const auto &queue : by_priority) {
+        if (!queue.empty()) {
+          return false;
+        }
+      }
+      return true;
+    }
+  };
+
+  struct JobRecord {
+    JobQueue queue = JobQueue::Worker;
+    JobPriority priority = JobPriority::Normal;
+    JobCallable work;
+    std::vector<uint64_t> dependents;
+    std::vector<uint64_t> attached_barriers;
+    uint32_t remaining_job_dependencies = 0u;
+    uint32_t remaining_barrier_dependencies = 0u;
+    bool queued = false;
+    bool running = false;
+    bool complete = false;
+    std::exception_ptr exception;
+  };
+
+  struct BarrierRecord {
+    uint32_t remaining = 0u;
+    bool fired = false;
+    std::vector<uint64_t> waiting_jobs;
+  };
+
+  JobHandle submit_locked(
+      std::span<const JobHandle> dependencies,
+      JobBarrier barrier,
+      JobCallable work,
+      JobQueue queue,
+      JobPriority priority
+  ) {
+    ASTRA_ENSURE(!work, "Cannot submit an empty job");
+
+    std::lock_guard lock(m_mutex);
+    ASTRA_ENSURE(m_stopping, "JobSystem is shutting down");
+
+    JobHandle handle{.id = m_next_job_id++};
+    auto &job = m_jobs[handle.id];
+    job.queue = queue;
+    job.priority = priority;
+    job.work = std::move(work);
+
+    for (const auto &dependency : dependencies) {
+      if (!dependency.is_valid()) {
+        continue;
+      }
+
+      auto dep_it = m_jobs.find(dependency.id);
+      ASTRA_ENSURE(dep_it == m_jobs.end(), "Unknown dependency job handle");
+
+      if (dep_it->second.complete) {
+        continue;
+      }
+
+      dep_it->second.dependents.push_back(handle.id);
+      ++job.remaining_job_dependencies;
+    }
+
+    if (barrier.is_valid()) {
+      auto barrier_it = m_barriers.find(barrier.id);
+      ASTRA_ENSURE(barrier_it == m_barriers.end(), "Unknown job barrier");
+
+      if (!barrier_it->second.fired) {
+        barrier_it->second.waiting_jobs.push_back(handle.id);
+        ++job.remaining_barrier_dependencies;
+      }
+    }
+
+    ++m_incomplete_jobs;
+
+    LOG_DEBUG(
+        "[JobSystem] submitted job",
+        "job_id=", handle.id,
+        "queue=", queue_name(queue),
+        "priority=", priority_name(priority),
+        "job_dependencies=", job.remaining_job_dependencies,
+        "barrier_dependencies=", job.remaining_barrier_dependencies
+    );
+
+    if (job.remaining_job_dependencies == 0u &&
+        job.remaining_barrier_dependencies == 0u) {
+      enqueue_ready_locked(handle.id, job.queue, job.priority);
+      m_ready_cv.notify_one();
+    }
+
+    return handle;
+  }
+
+  void worker_loop() {
+    for (;;) {
+      JobCallable work;
+      uint64_t job_id = 0u;
+
+      {
+        std::unique_lock lock(m_mutex);
+        m_ready_cv.wait(lock, [this]() {
+          return m_stopping || has_worker_ready_jobs_locked();
+        });
+
+        if (m_stopping && !has_worker_ready_jobs_locked()) {
+          return;
+        }
+
+        job_id = pop_ready_job_locked(m_worker_ready);
+        if (job_id == 0u) {
+          job_id = pop_ready_job_locked(m_background_ready);
+        }
+
+        if (job_id == 0u) {
+          continue;
+        }
+
+        auto &job = m_jobs.at(job_id);
+        job.queued = false;
+        job.running = true;
+        ++m_running_jobs;
+        work = std::move(job.work);
+      }
+
+      execute_job(job_id, std::move(work));
+    }
+  }
+
+  void execute_job(uint64_t job_id, JobCallable work) {
+    std::exception_ptr exception;
+
+    try {
+      if (work) {
+        work();
+      }
+    } catch (...) {
+      exception = std::current_exception();
+    }
+
+    std::lock_guard lock(m_mutex);
+    complete_job_locked(job_id, exception);
+  }
+
+  void complete_job_locked(uint64_t job_id, std::exception_ptr exception) {
+    auto job_it = m_jobs.find(job_id);
+    if (job_it == m_jobs.end() || job_it->second.complete) {
+      return;
+    }
+
+    auto &job = job_it->second;
+    job.complete = true;
+    job.running = false;
+    job.exception = exception;
+
+    if (exception != nullptr) {
+      LOG_ERROR(
+          "[JobSystem] job failed",
+          "job_id=", job_id,
+          "queue=", queue_name(job.queue),
+          "priority=", priority_name(job.priority)
+      );
+    }
+
+    if (m_running_jobs > 0u) {
+      --m_running_jobs;
+    }
+    if (m_incomplete_jobs > 0u) {
+      --m_incomplete_jobs;
+    }
+
+    auto dependents = std::move(job.dependents);
+    auto barriers = std::move(job.attached_barriers);
+    job.dependents.clear();
+    job.attached_barriers.clear();
+
+    for (uint64_t barrier_id : barriers) {
+      complete_barrier_attachment_locked(barrier_id);
+    }
+
+    for (uint64_t dependent_id : dependents) {
+      auto dependent_it = m_jobs.find(dependent_id);
+      if (dependent_it == m_jobs.end() || dependent_it->second.complete) {
+        continue;
+      }
+
+      auto &dependent = dependent_it->second;
+      if (dependent.remaining_job_dependencies > 0u) {
+        --dependent.remaining_job_dependencies;
+      }
+
+      if (dependent.remaining_job_dependencies == 0u &&
+          dependent.remaining_barrier_dependencies == 0u &&
+          !dependent.queued && !dependent.running) {
+        enqueue_ready_locked(
+            dependent_id, dependent.queue, dependent.priority
+        );
+      }
+    }
+
+    m_completion_cv.notify_all();
+    m_ready_cv.notify_all();
+  }
+
+  void complete_barrier_attachment_locked(uint64_t barrier_id) {
+    auto barrier_it = m_barriers.find(barrier_id);
+    if (barrier_it == m_barriers.end() || barrier_it->second.fired) {
+      return;
+    }
+
+    auto &barrier = barrier_it->second;
+    if (barrier.remaining > 0u) {
+      --barrier.remaining;
+    }
+
+    if (barrier.remaining != 0u) {
+      return;
+    }
+
+    barrier.fired = true;
+    auto waiting_jobs = std::move(barrier.waiting_jobs);
+    barrier.waiting_jobs.clear();
+
+    for (uint64_t waiting_job_id : waiting_jobs) {
+      auto job_it = m_jobs.find(waiting_job_id);
+      if (job_it == m_jobs.end() || job_it->second.complete) {
+        continue;
+      }
+
+      auto &job = job_it->second;
+      if (job.remaining_barrier_dependencies > 0u) {
+        --job.remaining_barrier_dependencies;
+      }
+
+      if (job.remaining_job_dependencies == 0u &&
+          job.remaining_barrier_dependencies == 0u &&
+          !job.queued && !job.running) {
+        enqueue_ready_locked(waiting_job_id, job.queue, job.priority);
+      }
+    }
+  }
+
+  void enqueue_ready_locked(
+      uint64_t job_id,
+      JobQueue queue,
+      JobPriority priority
+  ) {
+    auto &ready = ready_queue_locked(queue);
+    ready.by_priority[priority_index(priority)].push_back(job_id);
+    m_jobs.at(job_id).queued = true;
+  }
+
+  ReadyQueues &ready_queue_locked(JobQueue queue) {
+    switch (queue) {
+      case JobQueue::Worker:
+        return m_worker_ready;
+      case JobQueue::Main:
+        return m_main_ready;
+      case JobQueue::Background:
+        return m_background_ready;
+    }
+
+    return m_worker_ready;
+  }
+
+  uint64_t pop_ready_job_locked(ReadyQueues &ready) {
+    for (JobPriority priority : k_priority_order) {
+      auto &bucket = ready.by_priority[priority_index(priority)];
+      if (bucket.empty()) {
+        continue;
+      }
+
+      uint64_t job_id = bucket.front();
+      bucket.pop_front();
+      return job_id;
+    }
+
+    return 0u;
+  }
+
+  bool has_worker_ready_jobs_locked() const {
+    return !m_worker_ready.empty() || !m_background_ready.empty();
+  }
+
+  void wait_for_quiescence() {
+    for (;;) {
+      {
+        std::lock_guard lock(m_mutex);
+        if (m_incomplete_jobs == 0u) {
+          return;
+        }
+      }
+
+      if (is_main_thread() && drain_main_queue(1u) > 0u) {
+        continue;
+      }
+
+      std::unique_lock lock(m_mutex);
+      m_completion_cv.wait_for(lock, std::chrono::milliseconds(1));
+    }
+  }
+
+  bool is_main_thread() const noexcept {
+    return std::this_thread::get_id() == m_main_thread_id;
+  }
+
+  std::thread::id m_main_thread_id;
+  mutable std::mutex m_mutex;
+  std::condition_variable m_ready_cv;
+  std::condition_variable m_completion_cv;
+  std::vector<std::thread> m_worker_threads;
+  std::unordered_map<uint64_t, JobRecord> m_jobs;
+  std::unordered_map<uint64_t, BarrierRecord> m_barriers;
+  ReadyQueues m_worker_ready;
+  ReadyQueues m_main_ready;
+  ReadyQueues m_background_ready;
+  uint64_t m_next_job_id = 1u;
+  uint64_t m_next_barrier_id = 1u;
+  size_t m_incomplete_jobs = 0u;
+  size_t m_running_jobs = 0u;
+  bool m_stopping = false;
+};
+
+} // namespace
+
+JobSystem *JobSystem::m_instance = nullptr;
+static JobSystemImpl *g_job_system_impl = nullptr;
+
+JobSystem::JobSystem() = default;
+
+JobSystem::JobSystem(Config config) : m_config(config) {}
+
+JobSystem::~JobSystem() = default;
+
+JobSystem *JobSystem::get() { return m_instance; }
+
+void JobSystem::start() {
+  if (m_instance == nullptr) {
+    m_instance = this;
+  }
+
+  if (g_job_system_impl == nullptr) {
+    g_job_system_impl = new JobSystemImpl(m_config);
+  }
+}
+
+void JobSystem::end() {
+  if (g_job_system_impl != nullptr) {
+    g_job_system_impl->shutdown();
+    delete g_job_system_impl;
+    g_job_system_impl = nullptr;
+  }
+
+  if (m_instance == this) {
+    m_instance = nullptr;
+  }
+}
+
+void JobSystem::fixed_update(double fixed_dt) { (void)fixed_dt; }
+
+void JobSystem::pre_update(double dt) { (void)dt; }
+
+void JobSystem::update(double dt) { (void)dt; }
+
+JobHandle JobSystem::submit(
+    JobCallable work,
+    JobQueue queue,
+    JobPriority priority
+) {
+  return g_job_system_impl->submit(std::move(work), queue, priority);
+}
+
+JobHandle JobSystem::submit_after(
+    std::span<const JobHandle> dependencies,
+    JobCallable work,
+    JobQueue queue,
+    JobPriority priority
+) {
+  return g_job_system_impl->submit_after(
+      dependencies, std::move(work), queue, priority
+  );
+}
+
+JobBarrier JobSystem::create_barrier(uint32_t expected_count) {
+  return g_job_system_impl->create_barrier(expected_count);
+}
+
+void JobSystem::attach_to_barrier(JobHandle handle, JobBarrier barrier) {
+  g_job_system_impl->attach_to_barrier(handle, barrier);
+}
+
+JobHandle JobSystem::submit_after_barrier(
+    JobBarrier barrier,
+    JobCallable work,
+    JobQueue queue,
+    JobPriority priority
+) {
+  return g_job_system_impl->submit_after_barrier(
+      barrier, std::move(work), queue, priority
+  );
+}
+
+bool JobSystem::is_complete(JobHandle handle) const {
+  return g_job_system_impl->is_complete(handle);
+}
+
+void JobSystem::wait(JobHandle handle) { g_job_system_impl->wait(handle); }
+
+void JobSystem::wait_all(std::span<const JobHandle> handles) {
+  g_job_system_impl->wait_all(handles);
+}
+
+void JobSystem::wait_barrier(JobBarrier barrier) {
+  g_job_system_impl->wait_barrier(barrier);
+}
+
+size_t JobSystem::drain_main_queue(size_t max_jobs) {
+  return g_job_system_impl->drain_main_queue(max_jobs);
+}
+
+bool JobSystem::has_pending_main_work() const {
+  return g_job_system_impl->has_pending_main_work();
+}
+
+} // namespace astralix

--- a/src/modules/jobs/systems/job-system/job-system.hpp
+++ b/src/modules/jobs/systems/job-system/job-system.hpp
@@ -1,0 +1,95 @@
+#pragma once
+
+#include "job-callable.hpp"
+#include "systems/system.hpp"
+
+#include <cstdint>
+#include <limits>
+#include <span>
+
+namespace astralix {
+
+enum class JobPriority : uint8_t {
+  Low,
+  Normal,
+  High,
+  Critical,
+};
+
+enum class JobQueue : uint8_t {
+  Worker,
+  Main,
+  Background,
+};
+
+struct JobHandle {
+  uint64_t id = 0;
+
+  bool is_valid() const noexcept { return id != 0; }
+};
+
+struct JobBarrier {
+  uint64_t id = 0;
+
+  bool is_valid() const noexcept { return id != 0; }
+};
+
+class JobSystem : public System<JobSystem> {
+public:
+  struct Config {
+    uint32_t worker_count = 0;
+  };
+
+  JobSystem();
+  explicit JobSystem(Config config);
+  ~JobSystem() override;
+
+  static JobSystem *get();
+
+  void start() override;
+  void end() override;
+  void fixed_update(double fixed_dt) override;
+  void pre_update(double dt) override;
+  void update(double dt) override;
+
+  JobHandle submit(
+      JobCallable work,
+      JobQueue queue = JobQueue::Worker,
+      JobPriority priority = JobPriority::Normal
+  );
+
+  JobHandle submit_after(
+      std::span<const JobHandle> dependencies,
+      JobCallable work,
+      JobQueue queue = JobQueue::Worker,
+      JobPriority priority = JobPriority::Normal
+  );
+
+  JobBarrier create_barrier(uint32_t expected_count);
+  void attach_to_barrier(JobHandle handle, JobBarrier barrier);
+
+  JobHandle submit_after_barrier(
+      JobBarrier barrier,
+      JobCallable work,
+      JobQueue queue = JobQueue::Worker,
+      JobPriority priority = JobPriority::Normal
+  );
+
+  bool is_complete(JobHandle handle) const;
+  void wait(JobHandle handle);
+  void wait_all(std::span<const JobHandle> handles);
+  void wait_barrier(JobBarrier barrier);
+
+  size_t
+  drain_main_queue(size_t max_jobs = std::numeric_limits<size_t>::max());
+  bool has_pending_main_work() const;
+
+private:
+  JobSystem(const JobSystem &) = delete;
+  JobSystem &operator=(const JobSystem &) = delete;
+
+  Config m_config;
+  static JobSystem *m_instance;
+};
+
+} // namespace astralix

--- a/src/modules/project/CMakeLists.txt
+++ b/src/modules/project/CMakeLists.txt
@@ -1,6 +1,9 @@
 file(GLOB_RECURSE PROJECT_SRC ${CMAKE_CURRENT_SOURCE_DIR}/*.cpp)
 file(GLOB_RECURSE PROJECT_HEADER ${CMAKE_CURRENT_SOURCE_DIR}/*.hpp)
 
+list(FILTER PROJECT_SRC EXCLUDE REGEX ".*\\.test\\.cpp$")
+list(FILTER PROJECT_HEADER EXCLUDE REGEX ".*\\.test\\.hpp$")
+
 add_library(project STATIC ${PROJECT_SRC} ${PROJECT_HEADER})
 
 include_directories(${CMAKE_CURRENT_SOURCE_DIR}/../../shared)

--- a/src/modules/project/assets/asset_binding.hpp
+++ b/src/modules/project/assets/asset_binding.hpp
@@ -1,0 +1,12 @@
+#pragma once
+
+#include <string>
+
+namespace astralix {
+
+struct AssetBindingConfig {
+  std::string id;
+  std::string asset_path;
+};
+
+} // namespace astralix

--- a/src/modules/project/assets/asset_cooker.cpp
+++ b/src/modules/project/assets/asset_cooker.cpp
@@ -1,0 +1,122 @@
+#include "assets/asset_cooker.hpp"
+
+#include "assert.hpp"
+#include "assets/asset_path.hpp"
+#include "entities/serializers/axmesh-serializer.hpp"
+#include "importers/model-importer.hpp"
+
+#include <cctype>
+#include <iomanip>
+#include <sstream>
+
+namespace astralix {
+namespace {
+
+uint64_t fnv1a_64(std::string_view input) {
+  uint64_t hash = 14695981039346656037ull;
+  for (unsigned char ch : input) {
+    hash ^= static_cast<uint64_t>(ch);
+    hash *= 1099511628211ull;
+  }
+  return hash;
+}
+
+std::string hex_suffix(uint64_t value) {
+  std::ostringstream out;
+  out << std::hex << std::nouppercase << std::setw(8) << std::setfill('0')
+      << static_cast<uint32_t>(value & 0xffffffffu);
+  return out.str();
+}
+
+std::string sanitize_stem(const std::filesystem::path &path) {
+  std::string stem = path.stem().string();
+  for (char &ch : stem) {
+    if (!std::isalnum(static_cast<unsigned char>(ch)) && ch != '-') {
+      ch = '-';
+    }
+  }
+  if (stem.empty()) {
+    stem = "asset";
+  }
+  return stem;
+}
+
+std::string to_manifest_asset_path(const ResolvedAssetPath &path) {
+  return format_asset_reference(path);
+}
+
+} // namespace
+
+AssetCooker::AssetCooker(AssetGraphConfig config) : m_graph(std::move(config)) {}
+
+AssetCookOutput AssetCooker::cook(
+    std::span<const AssetBindingConfig> roots,
+    const std::filesystem::path &output_root
+) {
+  m_graph.load_root_assets(roots);
+
+  AssetCookOutput output;
+  output.output_root = output_root.lexically_normal();
+  output.manifest_path = (output.output_root / "pack.axpack").lexically_normal();
+  output.manifest.assets.reserve(m_graph.records().size());
+
+  const auto artifact_models_root =
+      (output.output_root / "artifacts" / "models").lexically_normal();
+  std::filesystem::create_directories(artifact_models_root);
+
+  for (const auto *record : m_graph.topological_order()) {
+    PackManifestAsset manifest_asset{
+        .descriptor_id = record->descriptor_id,
+        .kind = record->kind,
+        .source_asset = to_manifest_asset_path(record->asset_path),
+    };
+
+    manifest_asset.dependency_ids.reserve(record->dependencies.size());
+    for (const auto &dependency : record->dependencies) {
+      manifest_asset.dependency_ids.push_back(dependency.descriptor_id);
+    }
+
+    if (record->kind == AssetKind::Model) {
+      const auto &payload = std::get<ModelAssetData>(record->payload);
+      auto imported = import_model_file(
+          m_graph.to_absolute_path(payload.source_path),
+          ModelImportSettings{
+              .triangulate = payload.import.triangulate,
+              .flip_uvs = payload.import.flip_uvs,
+              .generate_normals = payload.import.generate_normals,
+          }
+      );
+
+      ASTRA_ENSURE(
+          imported.material_slot_count != payload.material_asset_keys.size(),
+          "Model asset '",
+          record->descriptor_id,
+          "' declares ",
+          payload.material_asset_keys.size(),
+          " material asset(s) but importer found ",
+          imported.material_slot_count,
+          " material slot(s)"
+      );
+
+      const auto artifact_name =
+          sanitize_stem(record->asset_path.relative_path) + "-" +
+          hex_suffix(fnv1a_64(record->asset_key)) + ".axmesh";
+      const auto artifact_relative =
+          (std::filesystem::path("artifacts") / "models" / artifact_name)
+              .generic_string();
+      const auto artifact_absolute =
+          (output.output_root / artifact_relative).lexically_normal();
+
+      AxMeshSerializer::write(artifact_absolute, imported.meshes);
+      manifest_asset.artifacts.push_back(artifact_relative);
+      ++output.cooked_artifact_count;
+    }
+
+    output.manifest.assets.push_back(std::move(manifest_asset));
+  }
+
+  output.manifest.write(output.manifest_path);
+  return output;
+}
+
+} // namespace astralix

--- a/src/modules/project/assets/asset_cooker.hpp
+++ b/src/modules/project/assets/asset_cooker.hpp
@@ -1,0 +1,32 @@
+#pragma once
+
+#include "assets/asset_binding.hpp"
+#include "assets/asset_graph.hpp"
+#include "assets/pack_manifest.hpp"
+
+#include <filesystem>
+#include <span>
+
+namespace astralix {
+
+struct AssetCookOutput {
+  PackManifest manifest;
+  std::filesystem::path output_root;
+  std::filesystem::path manifest_path;
+  size_t cooked_artifact_count = 0;
+};
+
+class AssetCooker {
+public:
+  explicit AssetCooker(AssetGraphConfig config);
+
+  AssetCookOutput cook(
+      std::span<const AssetBindingConfig> roots,
+      const std::filesystem::path &output_root
+  );
+
+private:
+  AssetGraph m_graph;
+};
+
+} // namespace astralix

--- a/src/modules/project/assets/asset_graph.cpp
+++ b/src/modules/project/assets/asset_graph.cpp
@@ -1,0 +1,945 @@
+#include "assets/asset_graph.hpp"
+
+#include "adapters/file/file-stream-reader.hpp"
+#include "assert.hpp"
+#include "context-proxy.hpp"
+#include "log.hpp"
+#include "serialization-context.hpp"
+
+#include <algorithm>
+#include <cctype>
+#include <functional>
+#include <optional>
+#include <sstream>
+#include <string_view>
+#include <unordered_set>
+
+namespace astralix {
+namespace {
+
+using ParsedContext = Ref<SerializationContext>;
+
+struct ParsedAssetDefinition {
+  AssetKind kind = AssetKind::Texture2D;
+  AssetPayload payload = TerrainAssetData{};
+  std::vector<ResolvedAssetPath> dependencies;
+};
+
+std::string to_lower(std::string value) {
+  std::transform(
+      value.begin(), value.end(), value.begin(),
+      [](unsigned char ch) { return static_cast<char>(std::tolower(ch)); }
+  );
+  return value;
+}
+
+float read_number(ContextProxy ctx, float fallback = 0.0f) {
+  switch (ctx.kind()) {
+  case SerializationTypeKind::Float:
+    return ctx.as<float>();
+  case SerializationTypeKind::Int:
+    return static_cast<float>(ctx.as<int>());
+  default:
+    return fallback;
+  }
+}
+
+glm::vec3 read_vec3(
+    ContextProxy ctx,
+    const glm::vec3 &fallback = glm::vec3(0.0f)
+) {
+  if (ctx.kind() != SerializationTypeKind::Object) {
+    return fallback;
+  }
+
+  return glm::vec3(
+      read_number(ctx["x"], fallback.x),
+      read_number(ctx["y"], fallback.y),
+      read_number(ctx["z"], fallback.z)
+  );
+}
+
+glm::vec4 read_vec4(
+    ContextProxy ctx,
+    const glm::vec4 &fallback = glm::vec4(0.0f)
+) {
+  if (ctx.kind() != SerializationTypeKind::Object) {
+    return fallback;
+  }
+
+  return glm::vec4(
+      read_number(ctx["x"], fallback.x),
+      read_number(ctx["y"], fallback.y),
+      read_number(ctx["z"], fallback.z),
+      read_number(ctx["w"], fallback.w)
+  );
+}
+
+bool read_bool(ContextProxy ctx, bool fallback = false) {
+  if (ctx.kind() == SerializationTypeKind::Bool) {
+    return ctx.as<bool>();
+  }
+
+  return fallback;
+}
+
+std::optional<std::string> read_optional_string(ContextProxy ctx) {
+  if (ctx.kind() != SerializationTypeKind::String) {
+    return std::nullopt;
+  }
+
+  return ctx.as<std::string>();
+}
+
+std::string require_string(ContextProxy ctx, std::string_view message) {
+  ASTRA_ENSURE(ctx.kind() != SerializationTypeKind::String, message);
+  const auto value = ctx.as<std::string>();
+  ASTRA_ENSURE(value.empty(), message);
+  return value;
+}
+
+std::filesystem::path normalize_relative_path(
+    const std::filesystem::path &path,
+    std::string_view label
+) {
+  ASTRA_ENSURE(path.is_absolute(), label, " must be relative");
+  const auto normalized = path.lexically_normal();
+  const auto generic = normalized.generic_string();
+  ASTRA_ENSURE(
+      generic.empty() || generic == "." || generic == ".." ||
+          generic.starts_with("../"),
+      label,
+      " escapes its root: ",
+      generic
+  );
+  return normalized;
+}
+
+bool is_graph_asset_extension(const std::filesystem::path &path) {
+  const auto extension = to_lower(path.extension().string());
+  return extension == ".axtexture" || extension == ".axmaterial" ||
+         extension == ".axmodel" || extension == ".axfont" ||
+         extension == ".axsvg" || extension == ".axaudio" ||
+         extension == ".axterrain";
+}
+
+bool is_texture_asset_extension(const std::filesystem::path &path) {
+  return to_lower(path.extension().string()) == ".axtexture";
+}
+
+bool is_material_asset_extension(const std::filesystem::path &path) {
+  return to_lower(path.extension().string()) == ".axmaterial";
+}
+
+bool is_json_file(const std::filesystem::path &path) {
+  return to_lower(path.extension().string()).starts_with(".ax");
+}
+
+AssetKind asset_kind_from_path(const std::filesystem::path &path) {
+  const auto extension = to_lower(path.extension().string());
+
+  if (extension == ".axtexture") {
+    return AssetKind::Texture2D;
+  }
+  if (extension == ".axmaterial") {
+    return AssetKind::Material;
+  }
+  if (extension == ".axmodel") {
+    return AssetKind::Model;
+  }
+  if (extension == ".axfont") {
+    return AssetKind::Font;
+  }
+  if (extension == ".axsvg") {
+    return AssetKind::Svg;
+  }
+  if (extension == ".axaudio") {
+    return AssetKind::AudioClip;
+  }
+  if (extension == ".axterrain") {
+    return AssetKind::TerrainRecipe;
+  }
+
+  ASTRA_EXCEPTION("Unsupported asset extension: ", path.extension().string());
+}
+
+void require_version_1(ContextProxy version_ctx, std::string_view label) {
+  if (version_ctx.kind() == SerializationTypeKind::Unknown) {
+    ASTRA_EXCEPTION(label, " must declare version 1");
+  }
+
+  ASTRA_ENSURE(
+      version_ctx.kind() != SerializationTypeKind::Int,
+      label,
+      " version must be an integer"
+  );
+  ASTRA_ENSURE(
+      version_ctx.as<int>() != 1,
+      "Unsupported ",
+      label,
+      " version: ",
+      version_ctx.as<int>()
+  );
+}
+
+ParsedContext load_json_context(const std::filesystem::path &path) {
+  ASTRA_ENSURE(!std::filesystem::exists(path), "Asset file not found: ", path);
+  ASTRA_ENSURE(!std::filesystem::is_regular_file(path), "Asset path is not a file: ", path);
+  ASTRA_ENSURE(!is_json_file(path), "Asset file must use an .ax* extension: ", path);
+
+  FileStreamReader stream(path);
+  stream.read();
+
+  return SerializationContext::create(
+      SerializationFormat::Json,
+      stream.get_buffer()
+  );
+}
+
+std::optional<std::string> read_optional_asset_key(
+    std::vector<ResolvedAssetPath> &dependencies,
+    const std::function<ResolvedAssetPath(std::string_view)> &resolver,
+    ContextProxy ctx,
+    std::string_view expected_extension,
+    const std::function<std::string(const ResolvedAssetPath &)> &key_builder
+) {
+  if (ctx.kind() != SerializationTypeKind::String) {
+    return std::nullopt;
+  }
+
+  auto resolved = resolver(ctx.as<std::string>());
+  ASTRA_ENSURE(
+      to_lower(resolved.relative_path.extension().string()) !=
+          std::string(expected_extension),
+      "Expected asset reference with extension ",
+      expected_extension,
+      ", got ",
+      format_asset_reference(resolved)
+  );
+
+  dependencies.push_back(resolved);
+  return key_builder(resolved);
+}
+
+} // namespace
+
+AssetGraph::AssetGraph(AssetGraphConfig config) : m_config(std::move(config)) {}
+
+void AssetGraph::load_root_assets(std::span<const AssetBindingConfig> roots) {
+  m_records.clear();
+  m_topological_order.clear();
+  m_record_index_by_key.clear();
+  m_public_record_index_by_id.clear();
+  m_public_id_by_key.clear();
+  m_asset_key_by_public_id.clear();
+
+  for (const auto &root : roots) {
+    ASTRA_ENSURE(root.id.empty(), "Asset binding id is required");
+    ASTRA_ENSURE(
+        root.asset_path.empty(),
+        "Asset binding path is required for ",
+        root.id
+    );
+
+    const auto resolved = resolve_reference(std::nullopt, root.asset_path);
+    const auto asset_key = to_asset_key(resolved);
+
+    auto [id_it, inserted_public_id] =
+        m_asset_key_by_public_id.emplace(root.id, asset_key);
+    ASTRA_ENSURE(
+        !inserted_public_id && id_it->second != asset_key,
+        "Duplicate asset binding id: ",
+        root.id
+    );
+
+    auto [key_it, inserted_asset_key] =
+        m_public_id_by_key.emplace(asset_key, root.id);
+    ASTRA_ENSURE(
+        !inserted_asset_key && key_it->second != root.id,
+        "Multiple public IDs target the same asset: ",
+        format_asset_reference(resolved)
+    );
+
+    std::vector<std::string> stack;
+    load_asset_recursive(resolved, stack);
+  }
+
+  finalize_records();
+}
+
+const AssetRecord *AssetGraph::find_by_public_id(std::string_view id) const {
+  const auto it = m_public_record_index_by_id.find(std::string(id));
+  if (it == m_public_record_index_by_id.end()) {
+    return nullptr;
+  }
+
+  return &m_records[it->second];
+}
+
+const AssetRecord *
+AssetGraph::find_by_asset_path(const std::filesystem::path &path) const {
+  const auto normalized = path.lexically_normal();
+  const auto is_absolute = normalized.is_absolute();
+
+  for (const auto &record : m_records) {
+    if (is_absolute && record.absolute_path == normalized) {
+      return &record;
+    }
+
+    if (!is_absolute && record.asset_path.relative_path == normalized) {
+      return &record;
+    }
+  }
+
+  return nullptr;
+}
+
+const AssetRecord *
+AssetGraph::find_by_asset_key(const std::string &key) const {
+  auto it = m_record_index_by_key.find(key);
+  if (it == m_record_index_by_key.end()) {
+    return nullptr;
+  }
+
+  return &m_records[it->second];
+}
+
+std::span<const AssetRecord> AssetGraph::records() const { return m_records; }
+
+std::span<const AssetRecord *const> AssetGraph::topological_order() const {
+  return m_topological_order;
+}
+
+ResolvedAssetPath AssetGraph::resolve_reference(
+    const std::optional<ResolvedAssetPath> &owner_asset_path,
+    std::string_view reference
+) const {
+  ASTRA_ENSURE(reference.empty(), "Asset reference is empty");
+
+  std::string value(reference);
+  ResolvedAssetPath resolved;
+
+  if (value.starts_with('@')) {
+    const std::string_view value_view(value);
+    const auto slash_position = value_view.find('/', 1);
+    ASTRA_ENSURE(
+        slash_position == std::string_view::npos || slash_position <= 1 ||
+            slash_position + 1 >= value_view.size(),
+        "Invalid aliased asset path: ",
+        value
+    );
+
+    const auto alias = value_view.substr(1, slash_position - 1);
+    ASTRA_ENSURE(
+        alias != "engine" && alias != "project",
+        "Unknown asset alias: ",
+        std::string(alias)
+    );
+
+    resolved.base_directory =
+        alias == "engine" ? BaseDirectory::Engine : BaseDirectory::Project;
+    resolved.relative_path = normalize_relative_path(
+        std::filesystem::path(value.substr(slash_position + 1)),
+        "Aliased asset path"
+    );
+    return resolved;
+  }
+
+  if (owner_asset_path.has_value()) {
+    resolved.base_directory = owner_asset_path->base_directory;
+    resolved.relative_path = normalize_relative_path(
+        owner_asset_path->relative_path.parent_path() / value,
+        "Nested asset path"
+    );
+    return resolved;
+  }
+
+  resolved.base_directory = BaseDirectory::Project;
+  resolved.relative_path =
+      normalize_relative_path(std::filesystem::path(value), "Asset path");
+  return resolved;
+}
+
+std::filesystem::path
+AssetGraph::to_absolute_path(const ResolvedAssetPath &path) const {
+  switch (path.base_directory) {
+  case BaseDirectory::Engine:
+    return (m_config.engine_assets_root / path.relative_path).lexically_normal();
+  case BaseDirectory::Project:
+    return (m_config.project_resources_root / path.relative_path)
+        .lexically_normal();
+  default:
+    ASTRA_EXCEPTION("Unsupported asset base directory");
+  }
+}
+
+std::string AssetGraph::to_asset_key(const ResolvedAssetPath &path) const {
+  const auto prefix =
+      path.base_directory == BaseDirectory::Engine ? "engine/" : "project/";
+  return prefix + path.relative_path.lexically_normal().generic_string();
+}
+
+void AssetGraph::load_asset_recursive(
+    const ResolvedAssetPath &asset_path,
+    std::vector<std::string> &stack
+) {
+  const auto asset_key = to_asset_key(asset_path);
+
+  if (m_record_index_by_key.contains(asset_key)) {
+    return;
+  }
+
+  if (std::find(stack.begin(), stack.end(), asset_key) != stack.end()) {
+    std::ostringstream cycle;
+    for (const auto &step : stack) {
+      if (!cycle.str().empty()) {
+        cycle << " -> ";
+      }
+      cycle << step;
+    }
+    cycle << " -> " << asset_key;
+    ASTRA_EXCEPTION("Asset dependency cycle detected: ", cycle.str());
+  }
+
+  stack.push_back(asset_key);
+
+  const auto absolute_path = to_absolute_path(asset_path);
+  auto ctx = load_json_context(absolute_path);
+  ASTRA_ENSURE(
+      ctx->kind() != SerializationTypeKind::Object,
+      "Asset root must be an object: ",
+      absolute_path
+  );
+
+  const auto kind = asset_kind_from_path(asset_path.relative_path);
+  auto field = [&](const char *key) { return (*ctx)[key]; };
+
+  auto resolve_from_owner = [&](std::string_view reference) {
+    return resolve_reference(asset_path, reference);
+  };
+  auto key_builder = [&](const ResolvedAssetPath &resolved) {
+    return to_asset_key(resolved);
+  };
+
+  ParsedAssetDefinition parsed;
+  parsed.kind = kind;
+
+  switch (kind) {
+  case AssetKind::Texture2D: {
+    require_version_1(field("version"), ".axtexture");
+
+    TextureAssetData data;
+    data.source_path =
+        resolve_from_owner(require_string(field("source"), ".axtexture source is required"));
+    ASTRA_ENSURE(
+        is_graph_asset_extension(data.source_path.relative_path),
+        ".axtexture source must reference a raw payload, got ",
+        format_asset_reference(data.source_path)
+    );
+    data.flip = read_bool(field("flip"), false);
+
+    auto parameters = field("parameters");
+    if (parameters.kind() == SerializationTypeKind::Object) {
+      for (const auto &key : parameters.object_keys()) {
+        auto value_ctx = parameters[key];
+        ASTRA_ENSURE(
+            value_ctx.kind() != SerializationTypeKind::String,
+            ".axtexture parameter values must be strings"
+        );
+        data.parameters.push_back(
+            TextureParameterEntry{.key = key, .value = value_ctx.as<std::string>()}
+        );
+      }
+    }
+
+    parsed.payload = std::move(data);
+    break;
+  }
+  case AssetKind::Material: {
+    require_version_1(field("version"), ".axmaterial");
+
+    MaterialAssetData data;
+    auto textures = field("textures");
+    if (textures.kind() == SerializationTypeKind::Object) {
+      data.base_color_asset_key = read_optional_asset_key(
+          parsed.dependencies,
+          resolve_from_owner,
+          textures["base_color"],
+          ".axtexture",
+          key_builder
+      );
+      data.normal_asset_key = read_optional_asset_key(
+          parsed.dependencies,
+          resolve_from_owner,
+          textures["normal"],
+          ".axtexture",
+          key_builder
+      );
+      data.metallic_asset_key = read_optional_asset_key(
+          parsed.dependencies,
+          resolve_from_owner,
+          textures["metallic"],
+          ".axtexture",
+          key_builder
+      );
+      data.roughness_asset_key = read_optional_asset_key(
+          parsed.dependencies,
+          resolve_from_owner,
+          textures["roughness"],
+          ".axtexture",
+          key_builder
+      );
+      data.metallic_roughness_asset_key = read_optional_asset_key(
+          parsed.dependencies,
+          resolve_from_owner,
+          textures["metallic_roughness"],
+          ".axtexture",
+          key_builder
+      );
+      data.occlusion_asset_key = read_optional_asset_key(
+          parsed.dependencies,
+          resolve_from_owner,
+          textures["occlusion"],
+          ".axtexture",
+          key_builder
+      );
+      data.emissive_asset_key = read_optional_asset_key(
+          parsed.dependencies,
+          resolve_from_owner,
+          textures["emissive"],
+          ".axtexture",
+          key_builder
+      );
+      data.displacement_asset_key = read_optional_asset_key(
+          parsed.dependencies,
+          resolve_from_owner,
+          textures["displacement"],
+          ".axtexture",
+          key_builder
+      );
+    }
+
+    data.base_color_factor =
+        read_vec4(field("base_color_factor"), glm::vec4(1.0f));
+    data.emissive_factor =
+        read_vec3(field("emissive_factor"), glm::vec3(0.0f));
+    data.metallic_factor = read_number(field("metallic_factor"), 1.0f);
+    data.roughness_factor = read_number(field("roughness_factor"), 1.0f);
+    data.occlusion_strength = read_number(field("occlusion_strength"), 1.0f);
+    data.normal_scale = read_number(field("normal_scale"), 1.0f);
+    data.height_scale = read_number(field("height_scale"), 0.0f);
+    data.bloom_intensity = read_number(field("bloom_intensity"), 0.0f);
+    data.alpha_mask = read_bool(field("alpha_mask"), false);
+    data.alpha_blend = read_bool(field("alpha_blend"), false);
+    data.alpha_cutoff = read_number(field("alpha_cutoff"), 0.5f);
+    data.double_sided = read_bool(field("double_sided"), false);
+
+    if (const auto alpha_mode = read_optional_string(field("alpha_mode"));
+        alpha_mode.has_value()) {
+      const auto normalized = astralix::to_lower(*alpha_mode);
+      ASTRA_ENSURE(
+          normalized != "opaque" && normalized != "mask" &&
+              normalized != "blend",
+          "Unsupported .axmaterial alpha_mode: ",
+          *alpha_mode
+      );
+      data.alpha_mask = normalized == "mask";
+      data.alpha_blend = normalized == "blend";
+    }
+
+    parsed.payload = std::move(data);
+    break;
+  }
+  case AssetKind::Model: {
+    require_version_1(field("version"), ".axmodel");
+
+    ModelAssetData data;
+    data.source_path =
+        resolve_from_owner(require_string(field("source"), ".axmodel source is required"));
+    ASTRA_ENSURE(
+        is_graph_asset_extension(data.source_path.relative_path),
+        ".axmodel source must reference a raw payload, got ",
+        format_asset_reference(data.source_path)
+    );
+
+    auto import = field("import");
+    if (import.kind() == SerializationTypeKind::Object) {
+      data.import.triangulate =
+          read_bool(import["triangulate"], data.import.triangulate);
+      data.import.flip_uvs =
+          read_bool(import["flip_uvs"], data.import.flip_uvs);
+      data.import.generate_normals =
+          read_bool(import["generate_normals"], data.import.generate_normals);
+      data.import.calculate_tangents = read_bool(
+          import["calculate_tangents"],
+          data.import.calculate_tangents
+      );
+      data.import.pre_transform_vertices = read_bool(
+          import["pre_transform_vertices"],
+          data.import.pre_transform_vertices
+      );
+    }
+
+    auto materials = field("materials");
+    if (materials.kind() == SerializationTypeKind::Array) {
+      for (size_t index = 0; index < materials.size(); ++index) {
+        auto material_asset_key = read_optional_asset_key(
+            parsed.dependencies,
+            resolve_from_owner,
+            materials[static_cast<int>(index)],
+            ".axmaterial",
+            key_builder
+        );
+        ASTRA_ENSURE(
+            !material_asset_key.has_value(),
+            ".axmodel materials entries must be strings"
+        );
+        data.material_asset_keys.push_back(*material_asset_key);
+      }
+    }
+
+    parsed.payload = std::move(data);
+    break;
+  }
+  case AssetKind::Font:
+  case AssetKind::Svg:
+  case AssetKind::AudioClip: {
+    require_version_1(
+        field("version"),
+        kind == AssetKind::Font
+            ? ".axfont"
+            : (kind == AssetKind::Svg ? ".axsvg" : ".axaudio")
+    );
+
+    SingleSourceAssetData data;
+    data.source_path = resolve_from_owner(
+        require_string(field("source"), "Single-source asset source is required")
+    );
+    ASTRA_ENSURE(
+        is_graph_asset_extension(data.source_path.relative_path),
+        "Single-source asset source must reference a raw payload, got ",
+        format_asset_reference(data.source_path)
+    );
+    parsed.payload = std::move(data);
+    break;
+  }
+  case AssetKind::TerrainRecipe: {
+    auto terrain_root = field("terrain");
+    const bool wrapped =
+        terrain_root.kind() == SerializationTypeKind::Object;
+    auto terrain_field = [&](const char *key) {
+      return wrapped ? terrain_root[key] : field(key);
+    };
+
+    if (terrain_field("version").kind() != SerializationTypeKind::Unknown) {
+      ASTRA_ENSURE(
+          terrain_field("version").kind() != SerializationTypeKind::Int,
+          ".axterrain version must be an integer"
+      );
+      ASTRA_ENSURE(
+          terrain_field("version").as<int>() != 1,
+          "Unsupported .axterrain version: ",
+          terrain_field("version").as<int>()
+      );
+    }
+
+    TerrainAssetData data;
+    if (terrain_field("version").kind() == SerializationTypeKind::Int) {
+      data.version = static_cast<uint32_t>(terrain_field("version").as<int>());
+    }
+    parsed.payload = std::move(data);
+    break;
+  }
+  }
+
+  std::unordered_set<std::string> seen_dependencies;
+  std::vector<AssetDependency> dependencies;
+  dependencies.reserve(parsed.dependencies.size());
+
+  for (const auto &dependency_path : parsed.dependencies) {
+    ASTRA_ENSURE(
+        !is_graph_asset_extension(dependency_path.relative_path),
+        "Nested asset dependency must point to another .ax* file: ",
+        format_asset_reference(dependency_path)
+    );
+
+    const auto dependency_key = to_asset_key(dependency_path);
+    if (!seen_dependencies.insert(dependency_key).second) {
+      continue;
+    }
+
+    load_asset_recursive(dependency_path, stack);
+    dependencies.push_back(AssetDependency{
+        .asset_path = dependency_path,
+        .asset_key = dependency_key,
+        .descriptor_id = {},
+    });
+  }
+
+  stack.pop_back();
+
+  m_record_index_by_key.emplace(asset_key, m_records.size());
+  m_records.push_back(AssetRecord{
+      .kind = kind,
+      .asset_path = asset_path,
+      .asset_key = asset_key,
+      .absolute_path = absolute_path,
+      .descriptor_id = {},
+      .public_id = std::nullopt,
+      .dependencies = std::move(dependencies),
+      .payload = std::move(parsed.payload),
+  });
+}
+
+bool AssetGraph::reload_asset(const std::string &asset_key) {
+  auto index_it = m_record_index_by_key.find(asset_key);
+  if (index_it == m_record_index_by_key.end()) {
+    LOG_WARN("AssetGraph: reload_asset called for unknown key:", asset_key);
+    return false;
+  }
+
+  auto &record = m_records[index_it->second];
+  const auto absolute_path = to_absolute_path(record.asset_path);
+
+  std::error_code error_code;
+  if (!std::filesystem::exists(absolute_path, error_code)) {
+    LOG_ERROR("AssetGraph: asset file not found:", absolute_path.string());
+    return false;
+  }
+
+  LOG_INFO("AssetGraph: re-parsing", asset_key, "from", absolute_path.string());
+
+  auto ctx = load_json_context(absolute_path);
+  if (ctx->kind() != SerializationTypeKind::Object) {
+    LOG_ERROR("AssetGraph: asset root is not an object:", absolute_path.string());
+    return false;
+  }
+
+  const auto kind = asset_kind_from_path(record.asset_path.relative_path);
+  auto field = [&](const char *key) { return (*ctx)[key]; };
+
+  auto resolve_from_owner = [&](std::string_view reference) {
+    return resolve_reference(record.asset_path, reference);
+  };
+  auto key_builder = [&](const ResolvedAssetPath &resolved) {
+    return to_asset_key(resolved);
+  };
+
+  ParsedAssetDefinition parsed;
+  parsed.kind = kind;
+
+  switch (kind) {
+  case AssetKind::Texture2D: {
+    TextureAssetData data;
+    data.source_path = resolve_from_owner(
+        require_string(field("source"), ".axtexture source is required")
+    );
+    data.flip = read_bool(field("flip"), false);
+
+    auto parameters = field("parameters");
+    if (parameters.kind() == SerializationTypeKind::Object) {
+      for (const auto &key : parameters.object_keys()) {
+        auto value_ctx = parameters[key];
+        if (value_ctx.kind() == SerializationTypeKind::String) {
+          data.parameters.push_back(
+              TextureParameterEntry{.key = key, .value = value_ctx.as<std::string>()}
+          );
+        }
+      }
+    }
+
+    parsed.payload = std::move(data);
+    break;
+  }
+  case AssetKind::Material: {
+    MaterialAssetData data;
+    auto textures = field("textures");
+    if (textures.kind() == SerializationTypeKind::Object) {
+      data.base_color_asset_key = read_optional_asset_key(
+          parsed.dependencies, resolve_from_owner, textures["base_color"],
+          ".axtexture", key_builder
+      );
+      data.normal_asset_key = read_optional_asset_key(
+          parsed.dependencies, resolve_from_owner, textures["normal"],
+          ".axtexture", key_builder
+      );
+      data.metallic_asset_key = read_optional_asset_key(
+          parsed.dependencies, resolve_from_owner, textures["metallic"],
+          ".axtexture", key_builder
+      );
+      data.roughness_asset_key = read_optional_asset_key(
+          parsed.dependencies, resolve_from_owner, textures["roughness"],
+          ".axtexture", key_builder
+      );
+      data.metallic_roughness_asset_key = read_optional_asset_key(
+          parsed.dependencies, resolve_from_owner,
+          textures["metallic_roughness"], ".axtexture", key_builder
+      );
+      data.occlusion_asset_key = read_optional_asset_key(
+          parsed.dependencies, resolve_from_owner, textures["occlusion"],
+          ".axtexture", key_builder
+      );
+      data.emissive_asset_key = read_optional_asset_key(
+          parsed.dependencies, resolve_from_owner, textures["emissive"],
+          ".axtexture", key_builder
+      );
+      data.displacement_asset_key = read_optional_asset_key(
+          parsed.dependencies, resolve_from_owner, textures["displacement"],
+          ".axtexture", key_builder
+      );
+    }
+
+    data.base_color_factor =
+        read_vec4(field("base_color_factor"), glm::vec4(1.0f));
+    data.emissive_factor =
+        read_vec3(field("emissive_factor"), glm::vec3(0.0f));
+    data.metallic_factor = read_number(field("metallic_factor"), 1.0f);
+    data.roughness_factor = read_number(field("roughness_factor"), 1.0f);
+    data.occlusion_strength = read_number(field("occlusion_strength"), 1.0f);
+    data.normal_scale = read_number(field("normal_scale"), 1.0f);
+    data.height_scale = read_number(field("height_scale"), 0.0f);
+    data.bloom_intensity = read_number(field("bloom_intensity"), 0.0f);
+    data.alpha_mask = read_bool(field("alpha_mask"), false);
+    data.alpha_blend = read_bool(field("alpha_blend"), false);
+    data.alpha_cutoff = read_number(field("alpha_cutoff"), 0.5f);
+    data.double_sided = read_bool(field("double_sided"), false);
+
+    if (const auto alpha_mode = read_optional_string(field("alpha_mode"));
+        alpha_mode.has_value()) {
+      const auto normalized = astralix::to_lower(*alpha_mode);
+      data.alpha_mask = normalized == "mask";
+      data.alpha_blend = normalized == "blend";
+    }
+
+    parsed.payload = std::move(data);
+    break;
+  }
+  case AssetKind::Model: {
+    ModelAssetData data;
+    data.source_path = resolve_from_owner(
+        require_string(field("source"), ".axmodel source is required")
+    );
+
+    auto import_field = field("import");
+    if (import_field.kind() == SerializationTypeKind::Object) {
+      data.import.triangulate =
+          read_bool(import_field["triangulate"], data.import.triangulate);
+      data.import.flip_uvs =
+          read_bool(import_field["flip_uvs"], data.import.flip_uvs);
+      data.import.generate_normals =
+          read_bool(import_field["generate_normals"], data.import.generate_normals);
+      data.import.calculate_tangents = read_bool(
+          import_field["calculate_tangents"], data.import.calculate_tangents
+      );
+      data.import.pre_transform_vertices = read_bool(
+          import_field["pre_transform_vertices"],
+          data.import.pre_transform_vertices
+      );
+    }
+
+    auto materials = field("materials");
+    if (materials.kind() == SerializationTypeKind::Array) {
+      for (size_t index = 0; index < materials.size(); ++index) {
+        auto material_asset_key = read_optional_asset_key(
+            parsed.dependencies, resolve_from_owner,
+            materials[static_cast<int>(index)], ".axmaterial", key_builder
+        );
+        if (material_asset_key.has_value()) {
+          data.material_asset_keys.push_back(*material_asset_key);
+        }
+      }
+    }
+
+    parsed.payload = std::move(data);
+    break;
+  }
+  case AssetKind::Font:
+  case AssetKind::Svg:
+  case AssetKind::AudioClip: {
+    SingleSourceAssetData data;
+    data.source_path = resolve_from_owner(
+        require_string(field("source"), "Single-source asset source is required")
+    );
+    parsed.payload = std::move(data);
+    break;
+  }
+  case AssetKind::TerrainRecipe: {
+    auto terrain_root = field("terrain");
+    const bool wrapped =
+        terrain_root.kind() == SerializationTypeKind::Object;
+    auto terrain_field = [&](const char *key) {
+      return wrapped ? terrain_root[key] : field(key);
+    };
+
+    TerrainAssetData data;
+    if (terrain_field("version").kind() == SerializationTypeKind::Int) {
+      data.version = static_cast<uint32_t>(terrain_field("version").as<int>());
+    }
+    parsed.payload = std::move(data);
+    break;
+  }
+  }
+
+  std::vector<AssetDependency> dependencies;
+  dependencies.reserve(parsed.dependencies.size());
+  for (const auto &dependency_path : parsed.dependencies) {
+    const auto dependency_key = to_asset_key(dependency_path);
+    const auto dep_index_it = m_record_index_by_key.find(dependency_key);
+    ResourceDescriptorID dep_descriptor_id;
+    if (dep_index_it != m_record_index_by_key.end()) {
+      dep_descriptor_id = m_records[dep_index_it->second].descriptor_id;
+    } else {
+      dep_descriptor_id = "asset::" + dependency_key;
+    }
+
+    dependencies.push_back(AssetDependency{
+        .asset_path = dependency_path,
+        .asset_key = dependency_key,
+        .descriptor_id = dep_descriptor_id,
+    });
+  }
+
+  record.payload = std::move(parsed.payload);
+  record.dependencies = std::move(dependencies);
+
+  LOG_INFO(
+      "AssetGraph: reloaded", asset_key,
+      "with", record.dependencies.size(), "dependencies"
+  );
+
+  return true;
+}
+
+void AssetGraph::finalize_records() {
+  m_topological_order.clear();
+  m_public_record_index_by_id.clear();
+  m_topological_order.reserve(m_records.size());
+
+  for (size_t index = 0; index < m_records.size(); ++index) {
+    auto &record = m_records[index];
+    auto public_id_it = m_public_id_by_key.find(record.asset_key);
+    if (public_id_it != m_public_id_by_key.end()) {
+      record.public_id = public_id_it->second;
+      record.descriptor_id = public_id_it->second;
+      m_public_record_index_by_id.emplace(public_id_it->second, index);
+    } else {
+      record.descriptor_id = "asset::" + record.asset_key;
+    }
+  }
+
+  for (auto &record : m_records) {
+    for (auto &dependency : record.dependencies) {
+      const auto it = m_record_index_by_key.find(dependency.asset_key);
+      ASTRA_ENSURE(
+          it == m_record_index_by_key.end(),
+          "Missing asset dependency record for ",
+          dependency.asset_key
+      );
+      dependency.descriptor_id = m_records[it->second].descriptor_id;
+    }
+
+    m_topological_order.push_back(&record);
+  }
+}
+
+} // namespace astralix

--- a/src/modules/project/assets/asset_graph.hpp
+++ b/src/modules/project/assets/asset_graph.hpp
@@ -1,0 +1,55 @@
+#pragma once
+
+#include "asset_binding.hpp"
+#include "asset_record.hpp"
+
+#include <filesystem>
+#include <span>
+#include <string_view>
+#include <unordered_map>
+#include <vector>
+
+namespace astralix {
+
+struct AssetGraphConfig {
+  std::filesystem::path project_root;
+  std::filesystem::path project_resources_root;
+  std::filesystem::path engine_assets_root;
+};
+
+class AssetGraph {
+public:
+  explicit AssetGraph(AssetGraphConfig config);
+
+  void load_root_assets(std::span<const AssetBindingConfig> roots);
+
+  const AssetRecord *find_by_public_id(std::string_view id) const;
+  const AssetRecord *find_by_asset_path(const std::filesystem::path &path) const;
+  const AssetRecord *find_by_asset_key(const std::string &key) const;
+  std::filesystem::path to_absolute_path(const ResolvedAssetPath &path) const;
+  std::span<const AssetRecord> records() const;
+  std::span<const AssetRecord *const> topological_order() const;
+  bool reload_asset(const std::string &asset_key);
+
+private:
+  void load_asset_recursive(
+      const ResolvedAssetPath &asset_path,
+      std::vector<std::string> &stack
+  );
+  ResolvedAssetPath resolve_reference(
+      const std::optional<ResolvedAssetPath> &owner_asset_path,
+      std::string_view reference
+  ) const;
+  std::string to_asset_key(const ResolvedAssetPath &path) const;
+  void finalize_records();
+
+  AssetGraphConfig m_config;
+  std::vector<AssetRecord> m_records;
+  std::vector<const AssetRecord *> m_topological_order;
+  std::unordered_map<std::string, size_t> m_record_index_by_key;
+  std::unordered_map<std::string, size_t> m_public_record_index_by_id;
+  std::unordered_map<std::string, std::string> m_public_id_by_key;
+  std::unordered_map<std::string, std::string> m_asset_key_by_public_id;
+};
+
+} // namespace astralix

--- a/src/modules/project/assets/asset_graph.test.cpp
+++ b/src/modules/project/assets/asset_graph.test.cpp
@@ -1,0 +1,137 @@
+#include "assets/asset_graph.hpp"
+#include "exceptions/base-exception.hpp"
+
+#include <gtest/gtest.h>
+
+#include <filesystem>
+#include <fstream>
+
+namespace astralix {
+namespace {
+
+std::filesystem::path make_temp_root(const char *suffix) {
+  const auto root =
+      std::filesystem::temp_directory_path() / std::string(suffix);
+  std::filesystem::remove_all(root);
+  std::filesystem::create_directories(root);
+  return root;
+}
+
+void write_text(const std::filesystem::path &path, const std::string &text) {
+  std::filesystem::create_directories(path.parent_path());
+  std::ofstream out(path);
+  out << text;
+}
+
+TEST(AssetGraphTest, ResolvesProjectAndEngineAssetDependencies) {
+  const auto root = make_temp_root("astralix-asset-graph-resolve");
+  const auto project_root = root / "project";
+  const auto resources_root = project_root / "assets";
+  const auto engine_root = root / "engine";
+
+  write_text(resources_root / "textures" / "local.png", "png");
+  write_text(resources_root / "shared" / "project-normal.png", "png");
+  write_text(engine_root / "shared" / "engine-emissive.png", "png");
+
+  write_text(
+      resources_root / "textures" / "local.axtexture",
+      R"json({
+  "version": 1,
+  "source": "local.png",
+  "flip": false
+})json"
+  );
+  write_text(
+      resources_root / "shared" / "project-normal.axtexture",
+      R"json({
+  "version": 1,
+  "source": "project-normal.png",
+  "flip": false
+})json"
+  );
+  write_text(
+      engine_root / "shared" / "engine-emissive.axtexture",
+      R"json({
+  "version": 1,
+  "source": "engine-emissive.png",
+  "flip": false
+})json"
+  );
+  write_text(
+      resources_root / "materials" / "test.axmaterial",
+      R"json({
+  "version": 1,
+  "textures": {
+    "base_color": "../textures/local.axtexture",
+    "normal": "@project/shared/project-normal.axtexture",
+    "emissive": "@engine/shared/engine-emissive.axtexture"
+  }
+})json"
+  );
+
+  AssetGraph graph({
+      .project_root = project_root,
+      .project_resources_root = resources_root,
+      .engine_assets_root = engine_root,
+  });
+
+  std::vector<AssetBindingConfig> roots = {
+      {.id = "materials::test", .asset_path = "materials/test.axmaterial"},
+      {.id = "textures::project_normal",
+       .asset_path = "shared/project-normal.axtexture"},
+  };
+
+  graph.load_root_assets(roots);
+
+  ASSERT_EQ(graph.records().size(), 4u);
+  ASSERT_EQ(graph.topological_order().size(), 4u);
+
+  const auto *material = graph.find_by_public_id("materials::test");
+  ASSERT_NE(material, nullptr);
+  EXPECT_EQ(material->descriptor_id, "materials::test");
+  ASSERT_EQ(material->dependencies.size(), 3u);
+
+  const auto *project_normal =
+      graph.find_by_public_id("textures::project_normal");
+  ASSERT_NE(project_normal, nullptr);
+  EXPECT_EQ(project_normal->descriptor_id, "textures::project_normal");
+
+  EXPECT_EQ(material->dependencies[0].descriptor_id,
+            "asset::project/textures/local.axtexture");
+  EXPECT_EQ(material->dependencies[1].descriptor_id,
+            "textures::project_normal");
+  EXPECT_EQ(material->dependencies[2].descriptor_id,
+            "asset::engine/shared/engine-emissive.axtexture");
+}
+
+TEST(AssetGraphTest, RejectsMultiplePublicIdsForSameAsset) {
+  const auto root = make_temp_root("astralix-asset-graph-duplicates");
+  const auto project_root = root / "project";
+  const auto resources_root = project_root / "assets";
+
+  write_text(resources_root / "textures" / "local.png", "png");
+  write_text(
+      resources_root / "textures" / "local.axtexture",
+      R"json({
+  "version": 1,
+  "source": "local.png",
+  "flip": false
+})json"
+  );
+
+  AssetGraph graph({
+      .project_root = project_root,
+      .project_resources_root = resources_root,
+      .engine_assets_root = root / "engine",
+  });
+
+  std::vector<AssetBindingConfig> roots = {
+      {.id = "textures::one", .asset_path = "textures/local.axtexture"},
+      {.id = "textures::two", .asset_path = "textures/local.axtexture"},
+  };
+
+  EXPECT_THROW(graph.load_root_assets(roots), BaseException);
+}
+
+} // namespace
+} // namespace astralix

--- a/src/modules/project/assets/asset_kind.hpp
+++ b/src/modules/project/assets/asset_kind.hpp
@@ -1,0 +1,39 @@
+#pragma once
+
+#include <cstdint>
+#include <string_view>
+
+namespace astralix {
+
+enum class AssetKind : uint8_t {
+  Texture2D,
+  Material,
+  Model,
+  Font,
+  Svg,
+  AudioClip,
+  TerrainRecipe,
+};
+
+inline std::string_view asset_kind_name(AssetKind kind) {
+  switch (kind) {
+  case AssetKind::Texture2D:
+    return "texture2d";
+  case AssetKind::Material:
+    return "material";
+  case AssetKind::Model:
+    return "model";
+  case AssetKind::Font:
+    return "font";
+  case AssetKind::Svg:
+    return "svg";
+  case AssetKind::AudioClip:
+    return "audio";
+  case AssetKind::TerrainRecipe:
+    return "terrain";
+  }
+
+  return "unknown";
+}
+
+} // namespace astralix

--- a/src/modules/project/assets/asset_path.hpp
+++ b/src/modules/project/assets/asset_path.hpp
@@ -1,0 +1,31 @@
+#pragma once
+
+#include "path.hpp"
+
+#include <filesystem>
+#include <string>
+
+namespace astralix {
+
+struct ResolvedAssetPath {
+  BaseDirectory base_directory = BaseDirectory::Project;
+  std::filesystem::path relative_path;
+};
+
+inline std::string format_asset_reference(const ResolvedAssetPath &path) {
+  const auto normalized = path.relative_path.lexically_normal().generic_string();
+  if (path.base_directory == BaseDirectory::Engine) {
+    return "@engine/" + normalized;
+  }
+
+  return normalized;
+}
+
+inline Ref<Path> to_runtime_path(const ResolvedAssetPath &resolved) {
+  return Path::create(
+      resolved.relative_path.generic_string(),
+      resolved.base_directory
+  );
+}
+
+} // namespace astralix

--- a/src/modules/project/assets/asset_payload.hpp
+++ b/src/modules/project/assets/asset_payload.hpp
@@ -1,0 +1,77 @@
+#pragma once
+
+#include "asset_path.hpp"
+
+#include <glm/ext/vector_float3.hpp>
+#include <glm/ext/vector_float4.hpp>
+#include <optional>
+#include <string>
+#include <variant>
+#include <vector>
+
+namespace astralix {
+
+struct TextureParameterEntry {
+  std::string key;
+  std::string value;
+};
+
+struct TextureAssetData {
+  ResolvedAssetPath source_path;
+  bool flip = false;
+  std::vector<TextureParameterEntry> parameters;
+};
+
+struct MaterialAssetData {
+  std::optional<std::string> base_color_asset_key;
+  std::optional<std::string> normal_asset_key;
+  std::optional<std::string> metallic_asset_key;
+  std::optional<std::string> roughness_asset_key;
+  std::optional<std::string> metallic_roughness_asset_key;
+  std::optional<std::string> occlusion_asset_key;
+  std::optional<std::string> emissive_asset_key;
+  std::optional<std::string> displacement_asset_key;
+  glm::vec4 base_color_factor = glm::vec4(1.0f);
+  glm::vec3 emissive_factor = glm::vec3(0.0f);
+  float metallic_factor = 1.0f;
+  float roughness_factor = 1.0f;
+  float occlusion_strength = 1.0f;
+  float normal_scale = 1.0f;
+  float height_scale = 0.0f;
+  float bloom_intensity = 0.0f;
+  bool alpha_mask = false;
+  bool alpha_blend = false;
+  float alpha_cutoff = 0.5f;
+  bool double_sided = false;
+};
+
+struct ModelImportConfig {
+  bool triangulate = true;
+  bool flip_uvs = true;
+  bool generate_normals = true;
+  bool calculate_tangents = true;
+  bool pre_transform_vertices = false;
+};
+
+struct ModelAssetData {
+  ResolvedAssetPath source_path;
+  ModelImportConfig import;
+  std::vector<std::string> material_asset_keys;
+};
+
+struct SingleSourceAssetData {
+  ResolvedAssetPath source_path;
+};
+
+struct TerrainAssetData {
+  uint32_t version = 1;
+};
+
+using AssetPayload = std::variant<
+    TextureAssetData,
+    MaterialAssetData,
+    ModelAssetData,
+    SingleSourceAssetData,
+    TerrainAssetData>;
+
+} // namespace astralix

--- a/src/modules/project/assets/asset_record.hpp
+++ b/src/modules/project/assets/asset_record.hpp
@@ -1,0 +1,32 @@
+#pragma once
+
+#include "asset_kind.hpp"
+#include "asset_path.hpp"
+#include "asset_payload.hpp"
+#include "guid.hpp"
+
+#include <filesystem>
+#include <optional>
+#include <string>
+#include <vector>
+
+namespace astralix {
+
+struct AssetDependency {
+  ResolvedAssetPath asset_path;
+  std::string asset_key;
+  ResourceDescriptorID descriptor_id;
+};
+
+struct AssetRecord {
+  AssetKind kind = AssetKind::Texture2D;
+  ResolvedAssetPath asset_path;
+  std::string asset_key;
+  std::filesystem::path absolute_path;
+  ResourceDescriptorID descriptor_id;
+  std::optional<ResourceDescriptorID> public_id;
+  std::vector<AssetDependency> dependencies;
+  AssetPayload payload;
+};
+
+} // namespace astralix

--- a/src/modules/project/assets/asset_registry.cpp
+++ b/src/modules/project/assets/asset_registry.cpp
@@ -1,0 +1,342 @@
+#include "assets/asset_registry.hpp"
+
+#include "assert.hpp"
+#include "log.hpp"
+#include "resources/audio-clip.hpp"
+#include "resources/font.hpp"
+#include "resources/material.hpp"
+#include "resources/model.hpp"
+#include "resources/svg.hpp"
+#include "resources/terrain-recipe.hpp"
+#include "resources/texture.hpp"
+
+namespace astralix {
+namespace {
+
+TextureParameter texture_param_from_string(const std::string &key) {
+  if (key == "wrap_s")
+    return TextureParameter::WrapS;
+  if (key == "wrap_t")
+    return TextureParameter::WrapT;
+  if (key == "mag_filter")
+    return TextureParameter::MagFilter;
+  if (key == "min_filter")
+    return TextureParameter::MinFilter;
+
+  ASTRA_EXCEPTION("Unknown texture parameter", key);
+}
+
+TextureValue texture_value_from_string(const std::string &value) {
+  if (value == "repeat")
+    return TextureValue::Repeat;
+  if (value == "clamp_to_edge")
+    return TextureValue::ClampToEdge;
+  if (value == "clamp_to_border")
+    return TextureValue::ClampToBorder;
+  if (value == "linear")
+    return TextureValue::Linear;
+  if (value == "nearest")
+    return TextureValue::Nearest;
+  if (value == "linear_mip_map")
+    return TextureValue::LinearMipMap;
+
+  ASTRA_EXCEPTION("Unknown texture value", value);
+}
+
+ModelImportSettings to_runtime_import_settings(
+    const ModelImportConfig &config
+) {
+  return ModelImportSettings{
+      .triangulate = config.triangulate,
+      .flip_uvs = config.flip_uvs,
+      .generate_normals = config.generate_normals,
+      .pre_transform_vertices = config.pre_transform_vertices,
+  };
+}
+
+} // namespace
+
+AssetRegistry::AssetRegistry(Ref<Project> project)
+    : m_project(std::move(project)),
+      m_graph(AssetGraphConfig{
+          .project_root =
+              std::filesystem::path(m_project->get_config().directory)
+                  .lexically_normal(),
+          .project_resources_root =
+              (std::filesystem::path(m_project->get_config().directory) /
+               m_project->get_config().resources.directory)
+                  .lexically_normal(),
+          .engine_assets_root = std::filesystem::path(ASTRALIX_ASSETS_DIR)
+                                    .lexically_normal(),
+      }),
+      m_watcher(AssetWatcher::Config{.poll_interval = std::chrono::milliseconds(500)}) {}
+
+AssetRegistry::~AssetRegistry() { m_watcher.stop(); }
+
+static constexpr const char *MANIFEST_WATCH_KEY = "__manifest__";
+
+void AssetRegistry::load_root_assets(std::span<const AssetBindingConfig> roots) {
+  m_graph.load_root_assets(roots);
+  register_records();
+  start_watcher();
+}
+
+void AssetRegistry::reload_all(std::span<const AssetBindingConfig> roots) {
+  LOG_INFO("AssetRegistry: reload_all triggered, releasing all records");
+
+  m_watcher.stop();
+
+  for (const auto &record : m_graph.records()) {
+    release_record(record);
+  }
+
+  m_graph.load_root_assets(roots);
+  register_records();
+  start_watcher();
+
+  LOG_INFO("AssetRegistry: reload_all complete,", m_graph.records().size(), "records");
+}
+
+void AssetRegistry::poll_reloads() {
+  auto changed_keys = m_watcher.poll_changed();
+  if (changed_keys.empty()) {
+    return;
+  }
+
+  for (const auto &asset_key : changed_keys) {
+    if (asset_key == MANIFEST_WATCH_KEY) {
+      LOG_INFO("AssetWatcher: project manifest changed, reloading");
+      m_project->reload_manifest();
+      return;
+    }
+
+    const auto *record = m_graph.find_by_asset_key(asset_key);
+    if (record == nullptr) {
+      continue;
+    }
+
+    LOG_INFO("AssetWatcher: reloading", asset_key);
+
+    release_record(*record);
+
+    if (!m_graph.reload_asset(asset_key)) {
+      LOG_ERROR("AssetWatcher: failed to reload", asset_key);
+      continue;
+    }
+
+    const auto *updated_record = m_graph.find_by_asset_key(asset_key);
+    if (updated_record == nullptr) {
+      continue;
+    }
+
+    register_record(*updated_record);
+    LOG_INFO("AssetWatcher: reloaded", asset_key);
+  }
+}
+
+const AssetRecord *AssetRegistry::find_by_public_id(std::string_view id) const {
+  return m_graph.find_by_public_id(id);
+}
+
+const AssetRecord *
+AssetRegistry::find_by_asset_path(const std::filesystem::path &path) const {
+  return m_graph.find_by_asset_path(path);
+}
+
+std::span<const AssetRecord> AssetRegistry::records() const {
+  return m_graph.records();
+}
+
+std::optional<ResourceDescriptorID> AssetRegistry::dependency_descriptor_id(
+    const AssetRecord &record,
+    const std::optional<std::string> &asset_key
+) const {
+  if (!asset_key.has_value()) {
+    return std::nullopt;
+  }
+
+  for (const auto &dependency : record.dependencies) {
+    if (dependency.asset_key == *asset_key) {
+      return dependency.descriptor_id;
+    }
+  }
+
+  ASTRA_EXCEPTION(
+      "Missing asset dependency for ",
+      record.descriptor_id,
+      ": ",
+      *asset_key
+  );
+}
+
+void AssetRegistry::register_records() {
+  for (const auto *record : m_graph.topological_order()) {
+    register_record(*record);
+  }
+}
+
+void AssetRegistry::register_record(const AssetRecord &record) {
+  LOG_INFO(
+      "AssetRegistry: registering", record.descriptor_id,
+      "(", asset_kind_name(record.kind), ")"
+  );
+
+  switch (record.kind) {
+  case AssetKind::Texture2D:
+    register_texture(record);
+    break;
+  case AssetKind::Material:
+    register_material(record);
+    break;
+  case AssetKind::Model:
+    register_model(record);
+    break;
+  case AssetKind::Font:
+    register_font(record);
+    break;
+  case AssetKind::Svg:
+    register_svg(record);
+    break;
+  case AssetKind::AudioClip:
+    register_audio_clip(record);
+    break;
+  case AssetKind::TerrainRecipe:
+    register_terrain_recipe(record);
+    break;
+  }
+}
+
+void AssetRegistry::release_record(const AssetRecord &record) {
+  LOG_INFO(
+      "AssetRegistry: releasing", record.descriptor_id,
+      "(", asset_kind_name(record.kind), ")"
+  );
+
+  auto manager = resource_manager();
+
+  switch (record.kind) {
+  case AssetKind::Texture2D:
+    manager->release_by_descriptor_id<Texture2DDescriptor>(record.descriptor_id);
+    break;
+  case AssetKind::Material:
+    manager->release_by_descriptor_id<MaterialDescriptor>(record.descriptor_id);
+    break;
+  case AssetKind::Model:
+    manager->release_by_descriptor_id<ModelDescriptor>(record.descriptor_id);
+    break;
+  case AssetKind::Font:
+    manager->release_by_descriptor_id<FontDescriptor>(record.descriptor_id);
+    break;
+  case AssetKind::Svg:
+    manager->release_by_descriptor_id<SvgDescriptor>(record.descriptor_id);
+    break;
+  case AssetKind::AudioClip:
+    manager->release_descriptor_by_id<AudioClipDescriptor>(record.descriptor_id);
+    break;
+  case AssetKind::TerrainRecipe:
+    manager->release_descriptor_by_id<TerrainRecipeDescriptor>(record.descriptor_id);
+    break;
+  }
+}
+
+void AssetRegistry::start_watcher() {
+  m_watcher.clear();
+  m_watcher.register_file(MANIFEST_WATCH_KEY, m_project->manifest_path());
+
+  for (const auto &record : m_graph.records()) {
+    m_watcher.register_file(record.asset_key, record.absolute_path);
+  }
+
+  m_watcher.start();
+  LOG_INFO("AssetWatcher: tracking", m_graph.records().size(), "asset files + manifest");
+}
+
+void AssetRegistry::register_texture(const AssetRecord &record) {
+  const auto &payload = std::get<TextureAssetData>(record.payload);
+  std::unordered_map<TextureParameter, TextureValue> parameters;
+  for (const auto &parameter : payload.parameters) {
+    parameters.emplace(
+        texture_param_from_string(parameter.key),
+        texture_value_from_string(parameter.value)
+    );
+  }
+
+  Texture2D::create(
+      record.descriptor_id,
+      to_runtime_path(payload.source_path),
+      payload.flip,
+      std::move(parameters)
+  );
+}
+
+void AssetRegistry::register_material(const AssetRecord &record) {
+  const auto &payload = std::get<MaterialAssetData>(record.payload);
+
+  Material::create(
+      record.descriptor_id,
+      dependency_descriptor_id(record, payload.base_color_asset_key),
+      dependency_descriptor_id(record, payload.normal_asset_key),
+      dependency_descriptor_id(record, payload.metallic_asset_key),
+      dependency_descriptor_id(record, payload.roughness_asset_key),
+      dependency_descriptor_id(record, payload.metallic_roughness_asset_key),
+      dependency_descriptor_id(record, payload.occlusion_asset_key),
+      dependency_descriptor_id(record, payload.emissive_asset_key),
+      dependency_descriptor_id(record, payload.displacement_asset_key),
+      payload.base_color_factor,
+      payload.emissive_factor,
+      payload.metallic_factor,
+      payload.roughness_factor,
+      payload.occlusion_strength,
+      payload.normal_scale,
+      payload.height_scale,
+      payload.bloom_intensity,
+      payload.alpha_mask,
+      payload.alpha_blend,
+      payload.alpha_cutoff,
+      payload.double_sided
+  );
+}
+
+void AssetRegistry::register_model(const AssetRecord &record) {
+  const auto &payload = std::get<ModelAssetData>(record.payload);
+
+  std::vector<ResourceDescriptorID> material_ids;
+  material_ids.reserve(payload.material_asset_keys.size());
+  for (const auto &asset_key : payload.material_asset_keys) {
+    auto material_id = dependency_descriptor_id(record, asset_key);
+    ASTRA_ENSURE(
+        !material_id.has_value(),
+        "Model asset dependency is missing a material descriptor id: ",
+        asset_key
+    );
+    material_ids.push_back(*material_id);
+  }
+
+  Model::create(
+      record.descriptor_id,
+      to_runtime_path(payload.source_path),
+      to_runtime_import_settings(payload.import),
+      std::move(material_ids)
+  );
+}
+
+void AssetRegistry::register_font(const AssetRecord &record) {
+  const auto &payload = std::get<SingleSourceAssetData>(record.payload);
+  Font::create(record.descriptor_id, to_runtime_path(payload.source_path));
+}
+
+void AssetRegistry::register_svg(const AssetRecord &record) {
+  const auto &payload = std::get<SingleSourceAssetData>(record.payload);
+  Svg::create(record.descriptor_id, to_runtime_path(payload.source_path));
+}
+
+void AssetRegistry::register_audio_clip(const AssetRecord &record) {
+  const auto &payload = std::get<SingleSourceAssetData>(record.payload);
+  AudioClip::create(record.descriptor_id, to_runtime_path(payload.source_path));
+}
+
+void AssetRegistry::register_terrain_recipe(const AssetRecord &record) {
+  TerrainRecipe::create(record.descriptor_id, to_runtime_path(record.asset_path));
+}
+
+} // namespace astralix

--- a/src/modules/project/assets/asset_registry.hpp
+++ b/src/modules/project/assets/asset_registry.hpp
@@ -1,0 +1,48 @@
+#pragma once
+
+#include "assets/asset_binding.hpp"
+#include "assets/asset_graph.hpp"
+#include "assets/asset_watcher.hpp"
+#include "project.hpp"
+
+#include <span>
+#include <string_view>
+
+namespace astralix {
+
+class AssetRegistry {
+public:
+  explicit AssetRegistry(Ref<Project> project);
+  ~AssetRegistry();
+
+  void load_root_assets(std::span<const AssetBindingConfig> roots);
+  void reload_all(std::span<const AssetBindingConfig> roots);
+  void poll_reloads();
+
+  const AssetRecord *find_by_public_id(std::string_view id) const;
+  const AssetRecord *find_by_asset_path(const std::filesystem::path &path) const;
+  std::span<const AssetRecord> records() const;
+
+private:
+  void register_records();
+  void register_record(const AssetRecord &record);
+  void release_record(const AssetRecord &record);
+  void register_texture(const AssetRecord &record);
+  void register_material(const AssetRecord &record);
+  void register_model(const AssetRecord &record);
+  void register_font(const AssetRecord &record);
+  void register_svg(const AssetRecord &record);
+  void register_audio_clip(const AssetRecord &record);
+  void register_terrain_recipe(const AssetRecord &record);
+  void start_watcher();
+  std::optional<ResourceDescriptorID> dependency_descriptor_id(
+      const AssetRecord &record,
+      const std::optional<std::string> &asset_key
+  ) const;
+
+  Ref<Project> m_project;
+  AssetGraph m_graph;
+  AssetWatcher m_watcher;
+};
+
+} // namespace astralix

--- a/src/modules/project/assets/asset_watcher.cpp
+++ b/src/modules/project/assets/asset_watcher.cpp
@@ -1,0 +1,97 @@
+#include "assets/asset_watcher.hpp"
+
+#include "log.hpp"
+
+#include <algorithm>
+
+namespace astralix {
+
+AssetWatcher::AssetWatcher(Config config) : m_config(std::move(config)) {}
+
+AssetWatcher::~AssetWatcher() { stop(); }
+
+void AssetWatcher::start() {
+  if (m_running.load()) return;
+  m_running.store(true);
+  m_thread = std::thread([this]() { watch_loop(); });
+  LOG_INFO("AssetWatcher: started");
+}
+
+void AssetWatcher::stop() {
+  if (!m_running.load()) return;
+  m_running.store(false);
+  if (m_thread.joinable()) {
+    m_thread.join();
+  }
+  LOG_INFO("AssetWatcher: stopped");
+}
+
+void AssetWatcher::clear() {
+  std::lock_guard lock(m_mutex);
+  m_watched_files.clear();
+  m_pending_reloads.clear();
+  LOG_INFO("AssetWatcher: cleared all watched files");
+}
+
+void AssetWatcher::register_file(
+    const std::string &asset_key,
+    const std::filesystem::path &absolute_path
+) {
+  std::lock_guard lock(m_mutex);
+
+  auto path_key = absolute_path.string();
+  if (m_watched_files.contains(path_key)) {
+    return;
+  }
+
+  std::error_code error_code;
+  auto mtime = std::filesystem::last_write_time(absolute_path, error_code);
+  if (error_code) {
+    mtime = std::filesystem::file_time_type::min();
+  }
+
+  m_watched_files.emplace(path_key, WatchedFile{
+      .path = absolute_path,
+      .last_mtime = mtime,
+      .asset_key = asset_key,
+  });
+
+  LOG_INFO("AssetWatcher: registered", asset_key, "->", absolute_path.string());
+}
+
+std::vector<std::string> AssetWatcher::poll_changed() {
+  std::lock_guard lock(m_mutex);
+  auto result = std::move(m_pending_reloads);
+  m_pending_reloads.clear();
+  return result;
+}
+
+void AssetWatcher::watch_loop() {
+  while (m_running.load()) {
+    std::this_thread::sleep_for(m_config.poll_interval);
+    if (!m_running.load()) break;
+
+    std::lock_guard lock(m_mutex);
+
+    for (auto &[path_key, watched] : m_watched_files) {
+      std::error_code error_code;
+      auto current_mtime =
+          std::filesystem::last_write_time(watched.path, error_code);
+      if (error_code) continue;
+      if (current_mtime <= watched.last_mtime) continue;
+
+      watched.last_mtime = current_mtime;
+
+      if (std::find(
+              m_pending_reloads.begin(),
+              m_pending_reloads.end(),
+              watched.asset_key
+          ) == m_pending_reloads.end()) {
+        LOG_INFO("AssetWatcher: change detected in", watched.asset_key);
+        m_pending_reloads.push_back(watched.asset_key);
+      }
+    }
+  }
+}
+
+} // namespace astralix

--- a/src/modules/project/assets/asset_watcher.hpp
+++ b/src/modules/project/assets/asset_watcher.hpp
@@ -1,0 +1,54 @@
+#pragma once
+
+#include <atomic>
+#include <chrono>
+#include <filesystem>
+#include <mutex>
+#include <string>
+#include <thread>
+#include <unordered_map>
+#include <vector>
+
+namespace astralix {
+
+class AssetWatcher {
+public:
+  struct Config {
+    std::chrono::milliseconds poll_interval{500};
+  };
+
+  explicit AssetWatcher(Config config);
+  ~AssetWatcher();
+
+  AssetWatcher(const AssetWatcher &) = delete;
+  AssetWatcher &operator=(const AssetWatcher &) = delete;
+
+  void start();
+  void stop();
+  void clear();
+
+  void register_file(
+      const std::string &asset_key,
+      const std::filesystem::path &absolute_path
+  );
+
+  std::vector<std::string> poll_changed();
+
+private:
+  void watch_loop();
+
+  struct WatchedFile {
+    std::filesystem::path path;
+    std::filesystem::file_time_type last_mtime;
+    std::string asset_key;
+  };
+
+  Config m_config;
+  std::mutex m_mutex;
+  std::unordered_map<std::string, WatchedFile> m_watched_files;
+  std::vector<std::string> m_pending_reloads;
+  std::thread m_thread;
+  std::atomic<bool> m_running{false};
+};
+
+} // namespace astralix

--- a/src/modules/project/assets/pack_manifest.cpp
+++ b/src/modules/project/assets/pack_manifest.cpp
@@ -1,0 +1,43 @@
+#include "assets/pack_manifest.hpp"
+
+#include "adapters/file/file-stream-writer.hpp"
+#include "arena.hpp"
+#include "serialization-context.hpp"
+#include "stream-buffer.hpp"
+
+namespace astralix {
+
+void PackManifest::write(const std::filesystem::path &path) const {
+  auto ctx = SerializationContext::create(SerializationFormat::Json);
+  (*ctx)["version"] = static_cast<int>(version);
+
+  for (size_t asset_index = 0; asset_index < assets.size(); ++asset_index) {
+    const auto &asset = assets[asset_index];
+    auto asset_ctx = (*ctx)["assets"][static_cast<int>(asset_index)];
+    asset_ctx["descriptor_id"] = asset.descriptor_id;
+    asset_ctx["kind"] = std::string(asset_kind_name(asset.kind));
+    asset_ctx["source_asset"] = asset.source_asset;
+
+    for (size_t dependency_index = 0;
+         dependency_index < asset.dependency_ids.size();
+         ++dependency_index) {
+      asset_ctx["dependency_ids"][static_cast<int>(dependency_index)] =
+          asset.dependency_ids[dependency_index];
+    }
+
+    for (size_t artifact_index = 0; artifact_index < asset.artifacts.size();
+         ++artifact_index) {
+      asset_ctx["artifacts"][static_cast<int>(artifact_index)] =
+          asset.artifacts[artifact_index];
+    }
+  }
+
+  std::filesystem::create_directories(path.parent_path());
+
+  ElasticArena arena(KB(64));
+  auto *block = ctx->to_buffer(arena);
+  auto writer = FileStreamWriter(path, clone_stream_buffer(block));
+  writer.write();
+}
+
+} // namespace astralix

--- a/src/modules/project/assets/pack_manifest.hpp
+++ b/src/modules/project/assets/pack_manifest.hpp
@@ -1,0 +1,27 @@
+#pragma once
+
+#include "assets/asset_kind.hpp"
+#include "guid.hpp"
+
+#include <filesystem>
+#include <string>
+#include <vector>
+
+namespace astralix {
+
+struct PackManifestAsset {
+  ResourceDescriptorID descriptor_id;
+  AssetKind kind = AssetKind::Texture2D;
+  std::string source_asset;
+  std::vector<ResourceDescriptorID> dependency_ids;
+  std::vector<std::string> artifacts;
+};
+
+struct PackManifest {
+  uint32_t version = 1;
+  std::vector<PackManifestAsset> assets;
+
+  void write(const std::filesystem::path &path) const;
+};
+
+} // namespace astralix

--- a/src/modules/project/managers/path-manager.cpp
+++ b/src/modules/project/managers/path-manager.cpp
@@ -5,6 +5,7 @@
 
 namespace astralix {
 constexpr std::string_view engineAssetsDirectory = ASTRALIX_ASSETS_DIR;
+constexpr std::string_view engineSourceAssetsDirectory = ASTRALIX_ENGINE_SOURCE_ASSETS_DIR;
 
 std::filesystem::path
 PathManager::resolve_project_path(std::string relative_path) {
@@ -41,5 +42,40 @@ std::filesystem::path PathManager::resolve(Ref<Path> path) {
   }
   }
 };
+
+std::filesystem::path
+PathManager::resolve_engine_source_path(std::string relative_path) {
+  return std::filesystem::path(engineSourceAssetsDirectory) / relative_path;
+}
+
+std::filesystem::path PathManager::resolve_source(Ref<Path> path) {
+  switch (path->get_base_directory()) {
+  case BaseDirectory::Project: {
+    return resolve_project_path(path->get_relative_path());
+  }
+  case BaseDirectory::Engine: {
+    return resolve_engine_source_path(path->get_relative_path());
+  }
+  default: {
+    ASTRA_EXCEPTION(std::string("Can't resolve source path basis"))
+  }
+  }
+}
+
+std::filesystem::path
+PathManager::remap_to_source(const std::filesystem::path &absolute_path) {
+  auto path_str = absolute_path.string();
+  auto install_prefix = std::string(engineAssetsDirectory);
+
+  if (path_str.starts_with(install_prefix)) {
+    auto relative = path_str.substr(install_prefix.size());
+    if (!relative.empty() && relative.front() == '/') {
+      relative.erase(relative.begin());
+    }
+    return std::filesystem::path(engineSourceAssetsDirectory) / relative;
+  }
+
+  return absolute_path;
+}
 
 } // namespace astralix

--- a/src/modules/project/managers/path-manager.hpp
+++ b/src/modules/project/managers/path-manager.hpp
@@ -11,10 +11,13 @@ public:
   PathManager() = default;
 
   std::filesystem::path resolve(Ref<Path> path);
+  std::filesystem::path resolve_source(Ref<Path> path);
+  std::filesystem::path remap_to_source(const std::filesystem::path &absolute_path);
 
 private:
   std::filesystem::path resolve_project_path(std::string relative_path);
   std::filesystem::path resolve_engine_path(std::string relative_path);
+  std::filesystem::path resolve_engine_source_path(std::string relative_path);
 };
 
 inline const Ref<PathManager> path_manager() noexcept {

--- a/src/modules/project/project.cpp
+++ b/src/modules/project/project.cpp
@@ -2,12 +2,14 @@
 
 #include "adapters/file/file-stream-reader.hpp"
 #include "arena.hpp"
+#include "assets/asset_registry.hpp"
 #include "assert.hpp"
 #include "guid.hpp"
 #include "log.hpp"
 #include "managers/path-manager.hpp"
 #include "managers/resource-manager.hpp"
 #include "serialization-context.hpp"
+#include "trace.hpp"
 #include <filesystem>
 
 namespace astralix {
@@ -36,31 +38,77 @@ Project::find_scene_entry(std::string_view id) const {
 }
 
 Ref<Project> Project::create(ProjectConfig config) {
+  ASTRA_PROFILE_N("Project::create");
 
   auto project = create_ref<Project>(config);
 
   ASTRA_ENSURE(config.directory.empty(), "Project path must be defined");
 
-  project->m_serializer = create_scope<ProjectSerializer>(
-      project, SerializationContext::create(config.serialization.format)
-  );
+  {
+    ASTRA_PROFILE_N("Project::create_serializer");
+    project->m_serializer = create_scope<ProjectSerializer>(
+        project, SerializationContext::create(config.serialization.format)
+    );
+  }
 
-  ResourceManager::init();
-  PathManager::init();
+  {
+    ASTRA_PROFILE_N("ResourceManager::init");
+    ResourceManager::init();
+  }
+  {
+    ASTRA_PROFILE_N("PathManager::init");
+    PathManager::init();
+  }
 
   const auto manifest_path = project->manifest_path();
 
   if (std::filesystem::exists(manifest_path)) {
+    ASTRA_PROFILE_N("Project::deserialize_manifest");
     auto stream = FileStreamReader(manifest_path);
     stream.read();
 
     project->m_serializer->get_ctx()->from_buffer(stream.get_buffer());
     project->m_serializer->deserialize();
   } else {
+    ASTRA_PROFILE_N("Project::serialize_manifest");
     project->m_serializer->serialize();
   }
 
+  {
+    ASTRA_PROFILE_N("AssetRegistry::load_root_assets");
+    project->m_asset_registry = create_scope<AssetRegistry>(project);
+    project->m_asset_registry->load_root_assets(
+        project->m_config.resources.asset_bindings
+    );
+  }
+
   return project;
+}
+
+void Project::reload_manifest() {
+  const auto path = manifest_path();
+
+  if (!std::filesystem::exists(path)) {
+    return;
+  }
+
+  auto stream = FileStreamReader(path);
+  stream.read();
+
+  m_serializer->get_ctx()->from_buffer(stream.get_buffer());
+  m_serializer->deserialize();
+
+  for (const auto &callback : m_manifest_reload_callbacks) {
+    callback(m_config);
+  }
+
+  if (m_asset_registry) {
+    m_asset_registry->reload_all(m_config.resources.asset_bindings);
+  }
+}
+
+void Project::on_manifest_reload(ManifestReloadCallback callback) {
+  m_manifest_reload_callbacks.push_back(std::move(callback));
 }
 
 void Project::save(ElasticArena &arena) {

--- a/src/modules/project/project.hpp
+++ b/src/modules/project/project.hpp
@@ -1,4 +1,5 @@
 #pragma once
+#include "assets/asset_binding.hpp"
 #include "arena.hpp"
 #include "assert.hpp"
 #include "base.hpp"
@@ -7,16 +8,19 @@
 #include "serialization-context.hpp"
 #include "serializers/project-serializer.hpp"
 #include "targets/render-target.hpp"
+#include <cstdint>
 #include <filesystem>
 #include <glm/ext/vector_float3.hpp>
 #include <map>
 #include <optional>
 #include <string>
+#include <functional>
 #include <string_view>
 
 namespace astralix {
 
 class ProjectSerializer;
+class AssetRegistry;
 
 #define RESOURCE_INIT_PARAMS const ResourceHandle &id
 
@@ -41,6 +45,7 @@ struct ProjectSerializationConfig {
 
 struct ProjectResourceConfig {
   std::string directory;
+  std::vector<AssetBindingConfig> asset_bindings;
 };
 
 struct ProjectSceneEntryConfig {
@@ -91,12 +96,256 @@ struct MSAAConfig {
   bool is_enabled;
 };
 
+struct SSAOConfig {
+  bool full_resolution = true;
+};
+
+struct SSGIConfig {
+  bool enabled = true;
+  bool full_resolution = false;
+  float intensity = 1.0f;
+  float radius = 1.5f;
+  float thickness = 0.15f;
+  int directions = 8;
+  int steps_per_direction = 2;
+  float max_distance = 2.0f;
+  bool temporal = true;
+  float history_weight = 0.9f;
+  float normal_reject_dot = 0.9f;
+  float position_reject_distance = 0.2f;
+};
+
+struct SSRConfig {
+  bool enabled = false;
+  float intensity = 1.0f;
+  float max_distance = 50.0f;
+  float thickness = 0.1f;
+  int max_steps = 64;
+  float stride = 1.0f;
+  float roughness_cutoff = 0.7f;
+};
+
+struct VolumetricFogConfig {
+  bool enabled = false;
+  int max_steps = 32;
+  float density = 0.02f;
+  float scattering = 0.7f;
+  float max_distance = 50.0f;
+  float intensity = 1.0f;
+  float fog_base_height = 0.0f;
+  float height_falloff_rate = 0.5f;
+  float noise_scale = 0.02f;
+  float noise_weight = 0.3f;
+  glm::vec3 wind_direction = glm::vec3(1.0f, 0.0f, 0.0f);
+  float wind_speed = 0.5f;
+  bool temporal = true;
+  float temporal_blend_weight = 0.85f;
+};
+
+struct LensFlareConfig {
+  bool enabled = false;
+  float intensity = 1.0f;
+  float threshold = 0.8f;
+  int ghost_count = 4;
+  float ghost_dispersal = 0.35f;
+  float ghost_weight = 0.5f;
+  float halo_radius = 0.6f;
+  float halo_weight = 0.25f;
+  float halo_thickness = 0.1f;
+  float chromatic_aberration = 0.02f;
+};
+
+struct EyeAdaptationConfig {
+  bool enabled = false;
+  float min_log_luminance = -8.0f;
+  float max_log_luminance = 4.0f;
+  float adaptation_speed_up = 3.0f;
+  float adaptation_speed_down = 1.0f;
+  float key_value = 0.18f;
+  float low_percentile = 0.05f;
+  float high_percentile = 0.95f;
+};
+
+struct MotionBlurConfig {
+  bool enabled = false;
+  float intensity = 1.0f;
+  int max_samples = 16;
+  float depth_threshold = 5.0f;
+};
+
+struct ChromaticAberrationConfig {
+  bool enabled = false;
+  float intensity = 0.005f;
+};
+
+struct VignetteConfig {
+  bool enabled = false;
+  float intensity = 0.3f;
+  float smoothness = 0.5f;
+  float roundness = 1.0f;
+};
+
+struct FilmGrainConfig {
+  bool enabled = false;
+  float intensity = 0.1f;
+};
+
+struct DepthOfFieldConfig {
+  bool enabled = false;
+  float focus_distance = 10.0f;
+  float focus_range = 5.0f;
+  float max_blur_radius = 5.0f;
+  int sample_count = 16;
+};
+
+enum class TonemapOperator : int {
+  Reinhard = 0,
+  AgX = 1,
+  ACES = 2,
+};
+
+struct TonemappingConfig {
+  TonemapOperator tonemap_operator = TonemapOperator::AgX;
+  float gamma = 2.2f;
+  float bloom_strength = 0.12f;
+};
+
+struct CASConfig {
+  bool enabled = false;
+  float sharpness = 0.5f;
+  float contrast = 0.0f;
+  float sharpening_limit = 0.25f;
+};
+
+struct TAAConfig {
+  bool enabled = false;
+  float blend_factor = 0.1f;
+};
+
+struct GodRaysConfig {
+  bool enabled = false;
+  float intensity = 1.0f;
+  float decay = 0.96f;
+  float density = 0.5f;
+  float weight = 0.4f;
+  float threshold = 0.8f;
+  int samples = 64;
+};
+
+struct SceneRenderOverrides {
+  std::optional<SSGIConfig> ssgi;
+  std::optional<SSRConfig> ssr;
+  std::optional<VolumetricFogConfig> volumetric;
+  std::optional<LensFlareConfig> lens_flare;
+  std::optional<EyeAdaptationConfig> eye_adaptation;
+  std::optional<MotionBlurConfig> motion_blur;
+  std::optional<ChromaticAberrationConfig> chromatic_aberration;
+  std::optional<VignetteConfig> vignette;
+  std::optional<FilmGrainConfig> film_grain;
+  std::optional<DepthOfFieldConfig> depth_of_field;
+  std::optional<GodRaysConfig> god_rays;
+  std::optional<CASConfig> cas;
+  std::optional<TAAConfig> taa;
+  std::optional<TonemappingConfig> tonemapping;
+
+  bool empty() const noexcept {
+    return !ssgi && !ssr && !volumetric && !lens_flare && !eye_adaptation &&
+           !motion_blur && !chromatic_aberration && !vignette && !film_grain &&
+           !depth_of_field && !god_rays && !cas && !taa && !tonemapping;
+  }
+};
+
+enum class RenderGraphSizeMode {
+  Absolute,
+  WindowRelative,
+};
+
+enum class RenderGraphPassDependencyKind : uint8_t {
+  Shader,
+  Texture2D,
+  Texture3D,
+  Material,
+  Model,
+  Font,
+  Svg,
+  AudioClip,
+  TerrainRecipe,
+};
+
+struct RenderGraphSizeConfig {
+  RenderGraphSizeMode mode = RenderGraphSizeMode::Absolute;
+  uint32_t width = 0;
+  uint32_t height = 0;
+  float scale_x = 1.0f;
+  float scale_y = 1.0f;
+  bool defined = false;
+};
+
+struct RenderGraphResourceConfig {
+  std::string name;
+  std::string format;
+  RenderGraphSizeConfig size;
+  std::vector<std::string> usage;
+  std::string lifetime = "transient";
+};
+
+struct RenderGraphPassDependencyConfig {
+  RenderGraphPassDependencyKind kind =
+      RenderGraphPassDependencyKind::Shader;
+  std::string slot;
+  ResourceDescriptorID descriptor_id;
+};
+
+struct RenderGraphPassUseConfig {
+  std::string resource;
+  std::string aspect;
+  std::string usage;
+};
+
+struct RenderGraphPassPresentConfig {
+  std::string resource;
+  std::string aspect = "color0";
+};
+
+struct RenderGraphPassConfig {
+  std::string id;
+  std::string type;
+  std::vector<RenderGraphPassDependencyConfig> dependencies;
+  std::vector<RenderGraphPassUseConfig> uses;
+  std::optional<RenderGraphPassPresentConfig> present;
+};
+
+struct RenderGraphConfig {
+  std::vector<RenderGraphResourceConfig> resources;
+  std::vector<RenderGraphPassConfig> passes;
+
+  bool is_defined() const noexcept {
+    return !resources.empty() || !passes.empty();
+  }
+};
+
 struct RenderSystemConfig {
   std::string backend;
   std::string strategy = "deferred";
   MSAAConfig msaa;
+  SSAOConfig ssao;
+  SSGIConfig ssgi;
+  SSRConfig ssr;
+  VolumetricFogConfig volumetric;
+  LensFlareConfig lens_flare;
+  EyeAdaptationConfig eye_adaptation;
+  MotionBlurConfig motion_blur;
+  ChromaticAberrationConfig chromatic_aberration;
+  VignetteConfig vignette;
+  FilmGrainConfig film_grain;
+  DepthOfFieldConfig depth_of_field;
+  GodRaysConfig god_rays;
+  CASConfig cas;
+  TAAConfig taa;
+  TonemappingConfig tonemapping;
   std::string window_id;
   bool headless = false;
+  RenderGraphConfig render_graph;
 
   RendererBackend backend_to_api() {
     if (backend == "opengl")
@@ -149,10 +398,12 @@ public:
   ProjectID get_project_id() const { return m_project_id; }
 
   static Ref<Project> create(ProjectConfig config);
+  AssetRegistry *asset_registry() const { return m_asset_registry.get(); }
   ProjectConfig &get_config() { return m_config; }
   const ProjectConfig &get_config() const { return m_config; }
   void save(ElasticArena &arena);
   void load(ElasticArena &arena);
+  void reload_manifest();
   std::filesystem::path manifest_path() const;
   std::filesystem::path resolve_path(
       const std::filesystem::path &relative_path
@@ -160,10 +411,15 @@ public:
   const ProjectSceneEntryConfig *find_scene_entry(std::string_view id) const;
   Project(ProjectConfig config);
 
+  using ManifestReloadCallback = std::function<void(const ProjectConfig &)>;
+  void on_manifest_reload(ManifestReloadCallback callback);
+
 private:
   ProjectConfig m_config;
   ProjectID m_project_id;
   Scope<ProjectSerializer> m_serializer;
+  Scope<AssetRegistry> m_asset_registry;
+  std::vector<ManifestReloadCallback> m_manifest_reload_callbacks;
 };
 
 } // namespace astralix

--- a/src/modules/project/serializers/project-serializer.cpp
+++ b/src/modules/project/serializers/project-serializer.cpp
@@ -36,6 +36,22 @@ enum class ResourceType {
   Unknown
 };
 
+bool has_inline_resource_fields(ContextProxy &asset) {
+  return asset["type"].kind() == SerializationTypeKind::String ||
+         asset["path"].kind() == SerializationTypeKind::String ||
+         asset["vertex"].kind() == SerializationTypeKind::String ||
+         asset["fragment"].kind() == SerializationTypeKind::String ||
+         asset["compute"].kind() == SerializationTypeKind::String ||
+         asset["geometry"].kind() == SerializationTypeKind::String ||
+         asset["faces"].kind() == SerializationTypeKind::Array ||
+         asset["equirectangular"].kind() == SerializationTypeKind::String ||
+         asset["textures"].kind() == SerializationTypeKind::Object;
+}
+
+bool is_asset_binding_entry(ContextProxy &asset) {
+  return asset["asset"].kind() == SerializationTypeKind::String;
+}
+
 Ref<Path> ProjectSerializer::parse_path(ContextProxy ctx) {
   std::string relative_path;
   BaseDirectory base_directory = BaseDirectory::Project;
@@ -139,6 +155,22 @@ glm::vec4 read_vec4(ContextProxy ctx, const glm::vec4 &fallback = glm::vec4(0.0f
   );
 }
 
+bool read_bool(ContextProxy ctx, bool fallback = false) {
+  if (ctx.kind() == SerializationTypeKind::Bool) {
+    return ctx.as<bool>();
+  }
+
+  return fallback;
+}
+
+std::optional<std::string> read_optional_string(ContextProxy ctx) {
+  if (ctx.kind() != SerializationTypeKind::String) {
+    return std::nullopt;
+  }
+
+  return ctx.as<std::string>();
+}
+
 ResourceType asset_type_from_string(const std::string &type) {
   if (type == "Texture2D")
     return ResourceType::Texture2D;
@@ -206,6 +238,499 @@ SceneStartupTarget scene_startup_target_from_string(const std::string &value) {
   ASTRA_EXCEPTION("Unknown scene startup target: ", value);
 }
 
+RenderGraphPassDependencyKind
+render_graph_dependency_kind_from_section(std::string_view section) {
+  if (section == "shaders") {
+    return RenderGraphPassDependencyKind::Shader;
+  }
+
+  if (section == "textures" || section == "textures_2d") {
+    return RenderGraphPassDependencyKind::Texture2D;
+  }
+
+  if (section == "textures_3d" || section == "cubemaps") {
+    return RenderGraphPassDependencyKind::Texture3D;
+  }
+
+  if (section == "materials") {
+    return RenderGraphPassDependencyKind::Material;
+  }
+
+  if (section == "models") {
+    return RenderGraphPassDependencyKind::Model;
+  }
+
+  if (section == "fonts") {
+    return RenderGraphPassDependencyKind::Font;
+  }
+
+  if (section == "svgs") {
+    return RenderGraphPassDependencyKind::Svg;
+  }
+
+  if (section == "audio_clips") {
+    return RenderGraphPassDependencyKind::AudioClip;
+  }
+
+  if (section == "terrain_recipes") {
+    return RenderGraphPassDependencyKind::TerrainRecipe;
+  }
+
+  ASTRA_EXCEPTION("Unknown render graph dependency section: ", section);
+}
+
+std::vector<std::string> read_string_array(ContextProxy ctx) {
+  std::vector<std::string> values;
+  if (ctx.kind() != SerializationTypeKind::Array) {
+    return values;
+  }
+
+  const auto count = ctx.size();
+  values.reserve(count);
+
+  for (int i = 0; i < count; ++i) {
+    auto item = ctx[i];
+    if (item.kind() == SerializationTypeKind::String) {
+      values.push_back(item.as<std::string>());
+    }
+  }
+
+  return values;
+}
+
+RenderGraphSizeConfig parse_render_graph_size(ContextProxy ctx) {
+  RenderGraphSizeConfig size;
+
+  switch (ctx.kind()) {
+    case SerializationTypeKind::String: {
+      const auto token = ctx.as<std::string>();
+      ASTRA_ENSURE(
+          token != "window",
+          "Unsupported render graph size token: ",
+          token,
+          ". Use \"window\" or an operation object."
+      );
+
+      size.mode = RenderGraphSizeMode::WindowRelative;
+      size.scale_x = 1.0f;
+      size.scale_y = 1.0f;
+      size.defined = true;
+      return size;
+    }
+
+    case SerializationTypeKind::Array: {
+      ASTRA_ENSURE(
+          ctx.size() < 2,
+          "Render graph absolute size arrays require [width, height]"
+      );
+
+      size.mode = RenderGraphSizeMode::Absolute;
+      size.width = static_cast<uint32_t>(read_number(ctx[0]));
+      size.height = static_cast<uint32_t>(read_number(ctx[1]));
+      size.defined = true;
+
+      ASTRA_ENSURE(
+          size.width == 0 || size.height == 0,
+          "Render graph absolute size must be greater than zero"
+      );
+
+      return size;
+    }
+
+    case SerializationTypeKind::Object: {
+      const auto width = static_cast<uint32_t>(read_number(ctx["width"]));
+      const auto height = static_cast<uint32_t>(read_number(ctx["height"]));
+      if (width > 0 && height > 0) {
+        size.mode = RenderGraphSizeMode::Absolute;
+        size.width = width;
+        size.height = height;
+        size.defined = true;
+        return size;
+      }
+
+      auto source_ctx = ctx["source"];
+      ASTRA_ENSURE(
+          source_ctx.kind() != SerializationTypeKind::String,
+          "Render graph size object requires either width/height or source"
+      );
+
+      const auto source = source_ctx.as<std::string>();
+      ASTRA_ENSURE(
+          source != "window",
+          "Unsupported render graph size source: ",
+          source
+      );
+
+      size.mode = RenderGraphSizeMode::WindowRelative;
+      size.scale_x = 1.0f;
+      size.scale_y = 1.0f;
+      size.defined = true;
+
+      auto op_ctx = ctx["op"];
+      if (op_ctx.kind() != SerializationTypeKind::String) {
+        return size;
+      }
+
+      const auto op = op_ctx.as<std::string>();
+      float scalar = read_number(ctx["value"], 1.0f);
+      float x = read_number(ctx["x"], scalar);
+      float y = read_number(ctx["y"], scalar);
+
+      ASTRA_ENSURE(
+          x <= 0.0f || y <= 0.0f,
+          "Render graph size operations require positive x/y values"
+      );
+
+      if (op == "multiply" || op == "scale") {
+        size.scale_x *= x;
+        size.scale_y *= y;
+        return size;
+      }
+
+      if (op == "divide") {
+        size.scale_x /= x;
+        size.scale_y /= y;
+        return size;
+      }
+
+      ASTRA_EXCEPTION("Unknown render graph size operation: ", op);
+    }
+
+    default:
+      break;
+  }
+
+  return size;
+}
+
+RenderGraphConfig parse_render_graph(ContextProxy ctx) {
+  RenderGraphConfig render_graph;
+  if (ctx.kind() != SerializationTypeKind::Object) {
+    return render_graph;
+  }
+
+  auto resources_ctx = ctx["resources"];
+  if (resources_ctx.kind() == SerializationTypeKind::Object) {
+    for (const auto &resource_name : resources_ctx.object_keys()) {
+      auto resource_ctx = resources_ctx[resource_name];
+
+      RenderGraphResourceConfig resource;
+      resource.name = resource_name;
+      if (resource_ctx["format"].kind() == SerializationTypeKind::String) {
+        resource.format = resource_ctx["format"].as<std::string>();
+      }
+      resource.size = parse_render_graph_size(resource_ctx["size"]);
+      resource.usage = read_string_array(resource_ctx["usage"]);
+      if (resource_ctx["lifetime"].kind() == SerializationTypeKind::String) {
+        resource.lifetime = resource_ctx["lifetime"].as<std::string>();
+      }
+
+      ASTRA_ENSURE(
+          resource.format.empty(),
+          "Render graph resource format is required for: ",
+          resource.name
+      );
+      ASTRA_ENSURE(
+          !resource.size.defined,
+          "Render graph size is required for resource: ",
+          resource.name
+      );
+      ASTRA_ENSURE(
+          resource.usage.empty(),
+          "Render graph usage list is required for resource: ",
+          resource.name
+      );
+
+      render_graph.resources.push_back(std::move(resource));
+    }
+  }
+
+  auto passes_ctx = ctx["passes"];
+  if (passes_ctx.kind() == SerializationTypeKind::Array) {
+    const auto pass_count = passes_ctx.size();
+    render_graph.passes.reserve(pass_count);
+
+    for (int pass_index = 0; pass_index < pass_count; ++pass_index) {
+      auto pass_ctx = passes_ctx[pass_index];
+
+      RenderGraphPassConfig pass;
+      if (pass_ctx["id"].kind() == SerializationTypeKind::String) {
+        pass.id = pass_ctx["id"].as<std::string>();
+      }
+      if (pass_ctx["type"].kind() == SerializationTypeKind::String) {
+        pass.type = pass_ctx["type"].as<std::string>();
+      }
+
+      auto dependencies_ctx = pass_ctx["dependencies"];
+      if (dependencies_ctx.kind() == SerializationTypeKind::Object) {
+        for (const auto &section : dependencies_ctx.object_keys()) {
+          auto section_ctx = dependencies_ctx[section];
+          if (section_ctx.kind() != SerializationTypeKind::Object) {
+            continue;
+          }
+
+          const auto kind =
+              render_graph_dependency_kind_from_section(section);
+          for (const auto &slot : section_ctx.object_keys()) {
+            auto descriptor_ctx = section_ctx[slot];
+            if (descriptor_ctx.kind() != SerializationTypeKind::String) {
+              continue;
+            }
+
+            pass.dependencies.push_back(RenderGraphPassDependencyConfig{
+                .kind = kind,
+                .slot = slot,
+                .descriptor_id = descriptor_ctx.as<std::string>(),
+            });
+          }
+        }
+      }
+
+      auto use_ctx = pass_ctx["use"];
+      if (use_ctx.kind() == SerializationTypeKind::Array) {
+        const auto use_count = use_ctx.size();
+        pass.uses.reserve(use_count);
+
+        for (int use_index = 0; use_index < use_count; ++use_index) {
+          auto current_use = use_ctx[use_index];
+          if (current_use.kind() != SerializationTypeKind::Object) {
+            continue;
+          }
+
+          RenderGraphPassUseConfig use;
+          if (current_use["resource"].kind() == SerializationTypeKind::String) {
+            use.resource = current_use["resource"].as<std::string>();
+          }
+          if (current_use["aspect"].kind() == SerializationTypeKind::String) {
+            use.aspect = current_use["aspect"].as<std::string>();
+          }
+          if (current_use["usage"].kind() == SerializationTypeKind::String) {
+            use.usage = current_use["usage"].as<std::string>();
+          }
+
+          ASTRA_ENSURE(
+              use.resource.empty() || use.aspect.empty() || use.usage.empty(),
+              "Render graph pass use entries require resource, aspect, and usage"
+          );
+
+          pass.uses.push_back(std::move(use));
+        }
+      }
+
+      auto present_ctx = pass_ctx["present"];
+      if (present_ctx.kind() == SerializationTypeKind::Object) {
+        RenderGraphPassPresentConfig present;
+        if (present_ctx["resource"].kind() == SerializationTypeKind::String) {
+          present.resource = present_ctx["resource"].as<std::string>();
+        }
+        if (present_ctx["aspect"].kind() == SerializationTypeKind::String) {
+          present.aspect = present_ctx["aspect"].as<std::string>();
+        }
+
+        ASTRA_ENSURE(
+            present.resource.empty(),
+            "Render graph present entries require a resource"
+        );
+
+        pass.present = std::move(present);
+      }
+
+      ASTRA_ENSURE(
+          pass.type.empty(),
+          "Render graph pass type is required"
+      );
+
+      render_graph.passes.push_back(std::move(pass));
+    }
+  }
+
+  return render_graph;
+}
+
+void deserialize_inline_resource(ProjectSerializer &serializer, ContextProxy &asset) {
+  auto id = asset["id"].as<std::string>();
+  auto type_str = asset["type"].as<std::string>();
+  auto asset_type = asset_type_from_string(type_str);
+
+  switch (asset_type) {
+  case ResourceType::Font: {
+    auto path = serializer.parse_path(asset["path"]);
+
+    ASTRA_ENSURE(path == nullptr, "Font path is required");
+
+    Font::create(id, path);
+    break;
+  }
+  case ResourceType::Texture3D: {
+    if (asset["equirectangular"].kind() == SerializationTypeKind::String) {
+      auto equirectangular_path = serializer.parse_path(asset["equirectangular"]);
+      Texture3D::create_from_equirectangular(id, equirectangular_path);
+    } else {
+      std::vector<Ref<Path>> faces;
+      auto face_size = asset["faces"].size();
+      for (int j = 0; j < face_size; j++) {
+        faces.push_back(serializer.parse_path(asset["faces"][j]));
+      }
+      Texture3D::create(id, faces);
+    }
+    break;
+  }
+  case ResourceType::Texture2D: {
+    auto path = serializer.parse_path(asset["path"]);
+    bool flip = asset["flip"].as<bool>();
+
+    std::unordered_map<TextureParameter, TextureValue> parameters;
+
+    auto parameters_size = asset["parameters"].size();
+
+    if (parameters_size > 0) {
+      for (int j = 0; j < parameters_size; j++) {
+        auto param = asset["parameters"][j];
+
+        auto key = param["key"].as<std::string>();
+        auto value = param["value"].as<std::string>();
+
+        parameters.emplace(
+            texture_param_from_string(key),
+            texture_value_from_string(value)
+        );
+      }
+    }
+
+    Texture2D::create(id, path, flip, parameters);
+    break;
+  }
+  case ResourceType::Material: {
+    ASTRA_ENSURE(
+        asset["textures"]["diffuse"].kind() !=
+                SerializationTypeKind::Unknown ||
+            asset["textures"]["specular"].kind() !=
+                SerializationTypeKind::Unknown,
+        "Material '",
+        id,
+        "' still uses classic material keys"
+    );
+    ASTRA_ENSURE(
+        asset["emissive"].kind() != SerializationTypeKind::Unknown,
+        "Material '",
+        id,
+        "' still uses classic material fields"
+    );
+
+    auto textures = asset["textures"];
+
+    auto read_optional_id = [](ContextProxy ctx)
+        -> std::optional<ResourceDescriptorID> {
+      if (ctx.kind() != SerializationTypeKind::String) {
+        return std::nullopt;
+      }
+
+      const auto value = ctx.as<std::string>();
+      if (value.empty()) {
+        return std::nullopt;
+      }
+
+      return value;
+    };
+
+    Material::create(
+        id,
+        read_optional_id(textures["base_color"]),
+        read_optional_id(textures["normal"]),
+        read_optional_id(textures["metallic"]),
+        read_optional_id(textures["roughness"]),
+        read_optional_id(textures["metallic_roughness"]),
+        read_optional_id(textures["occlusion"]),
+        read_optional_id(textures["emissive"]),
+        read_optional_id(textures["displacement"]),
+        read_vec4(asset["base_color_factor"], glm::vec4(1.0f)),
+        read_vec3(asset["emissive_factor"], glm::vec3(0.0f)),
+        read_number(asset["metallic_factor"], 1.0f),
+        read_number(asset["roughness_factor"], 1.0f),
+        read_number(asset["occlusion_strength"], 1.0f),
+        read_number(asset["normal_scale"], 1.0f),
+        read_number(asset["height_scale"], 0.02f),
+        read_number(asset["bloom_intensity"], 0.0f),
+        [&]() {
+          auto alpha_mode = read_optional_string(asset["alpha_mode"]);
+          if (alpha_mode.has_value()) {
+            const auto normalized = to_lower(*alpha_mode);
+            ASTRA_ENSURE(
+                normalized != "opaque" && normalized != "mask" &&
+                    normalized != "blend",
+                "Unsupported material alpha_mode: ",
+                *alpha_mode
+            );
+            return normalized == "mask";
+          }
+
+          return read_bool(asset["alpha_mask"], false);
+        }(),
+        [&]() {
+          auto alpha_mode = read_optional_string(asset["alpha_mode"]);
+          if (alpha_mode.has_value()) {
+            return to_lower(*alpha_mode) == "blend";
+          }
+          return read_bool(asset["alpha_blend"], false);
+        }(),
+        read_number(asset["alpha_cutoff"], 0.5f),
+        read_bool(asset["double_sided"], false)
+    );
+    break;
+  }
+  case ResourceType::Shader: {
+    auto vertex = serializer.parse_path(asset["vertex"]);
+    auto fragment = serializer.parse_path(asset["fragment"]);
+    auto geometry = serializer.parse_path(asset["geometry"]);
+    auto compute = serializer.parse_path(asset["compute"]);
+
+    Shader::create(id, fragment, vertex, geometry, compute);
+
+    break;
+  }
+  case ResourceType::Model: {
+    auto path = serializer.parse_path(asset["path"]);
+
+    ASTRA_ENSURE(path == nullptr, "Model path is required");
+
+    Model::create(id, path);
+    break;
+  }
+  case ResourceType::Svg: {
+    auto path = serializer.parse_path(asset["path"]);
+
+    ASTRA_ENSURE(path == nullptr, "SVG path is required");
+
+    Svg::create(id, path);
+    break;
+  }
+  case ResourceType::AudioClip: {
+    auto path = serializer.parse_path(asset["path"]);
+
+    ASTRA_ENSURE(path == nullptr, "AudioClip path is required");
+
+    AudioClip::create(id, path);
+    break;
+  }
+  case ResourceType::TerrainRecipe: {
+    auto path = serializer.parse_path(asset["path"]);
+
+    ASTRA_ENSURE(path == nullptr, "TerrainRecipe path is required");
+
+    TerrainRecipe::create(id, path);
+    break;
+  }
+  default: {
+    ExceptionMetadata metadata;
+
+    metadata.push_back({"id", id});
+    metadata.push_back({"type", type_str});
+
+    ASTRA_EXCEPTION_META(metadata, "Unknown asset type", type_str);
+  }
+  }
+}
+
 #define SET_CONFIG(value, key) \
   do {                         \
     auto &&_v = (value);       \
@@ -261,10 +786,13 @@ void ProjectSerializer::deserialize() {
   auto &config = m_project->get_config();
 
   SerializationContext &ctx = *m_ctx.get();
+  const RenderGraphConfig manifest_render_graph =
+      parse_render_graph(ctx["render_graph"]);
 
   config.windows.clear();
   config.systems.clear();
   config.scenes.entries.clear();
+  config.resources.asset_bindings.clear();
 
   SET_CONFIG(ctx["project"]["name"].as<std::string>(), name);
   SET_CONFIG(ctx["project"]["directory"].as<std::string>(), directory);
@@ -346,147 +874,42 @@ void ProjectSerializer::deserialize() {
 
   for (int i = 0; i < resources_size; i++) {
     auto asset = resources[i];
+    const bool asset_binding = is_asset_binding_entry(asset);
+    const bool inline_resource = has_inline_resource_fields(asset);
 
-    auto id = asset["id"].as<std::string>();
-    auto type_str = asset["type"].as<std::string>();
-    auto asset_type = asset_type_from_string(type_str);
+    ASTRA_ENSURE(
+        asset_binding && inline_resource,
+        "Resource entry mixes inline fields with an asset binding"
+    );
 
-    switch (asset_type) {
-      case ResourceType::Font: {
-        auto path = parse_path(asset["path"]);
+    if (asset_binding) {
+      auto id = asset["id"].as<std::string>();
+      ASTRA_ENSURE(id.empty(), "Asset binding id is required");
 
-        ASTRA_ENSURE(path == nullptr, "Font path is required");
+      config.resources.asset_bindings.push_back(AssetBindingConfig{
+          .id = std::move(id),
+          .asset_path =
+              asset["asset"].kind() == SerializationTypeKind::String
+                  ? asset["asset"].as<std::string>()
+                  : std::string{},
+      });
 
-        Font::create(id, path);
-        break;
-      }
-      case ResourceType::Texture3D: {
-        std::vector<Ref<Path>> faces;
-
-        auto face_size = asset["faces"].size();
-
-        for (int j = 0; j < face_size; j++) {
-          faces.push_back(parse_path(asset["faces"][j]));
-        }
-
-        Texture3D::create(id, faces);
-        break;
-      }
-      case ResourceType::Texture2D: {
-        auto path = parse_path(asset["path"]);
-        bool flip = asset["flip"].as<bool>();
-
-        std::unordered_map<TextureParameter, TextureValue> parameters;
-
-        auto parameters_size = asset["parameters"].size();
-
-        if (parameters_size > 0) {
-          for (int j = 0; j < parameters_size; j++) {
-            auto param = asset["parameters"][j];
-
-            auto key = param["key"].as<std::string>();
-            auto value = param["value"].as<std::string>();
-
-            parameters.emplace(texture_param_from_string(key), texture_value_from_string(value));
-          }
-        }
-
-        Texture2D::create(id, path, flip, parameters);
-        break;
-      }
-      case ResourceType::Material: {
-        ASTRA_ENSURE(
-            asset["textures"]["diffuse"].kind() !=
-                    SerializationTypeKind::Unknown ||
-                asset["textures"]["specular"].kind() !=
-                    SerializationTypeKind::Unknown,
-            "Material '", id, "' still uses classic material keys"
-        );
-        ASTRA_ENSURE(
-            asset["emissive"].kind() != SerializationTypeKind::Unknown,
-            "Material '", id, "' still uses classic material fields"
-        );
-
-        auto textures = asset["textures"];
-
-        auto read_optional_id = [](ContextProxy ctx)
-            -> std::optional<ResourceDescriptorID> {
-          if (ctx.kind() != SerializationTypeKind::String) {
-            return std::nullopt;
-          }
-
-          const auto value = ctx.as<std::string>();
-          if (value.empty()) {
-            return std::nullopt;
-          }
-
-          return value;
-        };
-
-        Material::create(
-            id,
-            read_optional_id(textures["base_color"]),
-            read_optional_id(textures["normal"]),
-            read_optional_id(textures["metallic"]),
-            read_optional_id(textures["roughness"]),
-            read_optional_id(textures["metallic_roughness"]),
-            read_optional_id(textures["occlusion"]),
-            read_optional_id(textures["emissive"]),
-            read_optional_id(textures["displacement"]),
-            read_vec4(asset["base_color_factor"], glm::vec4(1.0f)),
-            read_vec3(asset["emissive_factor"], glm::vec3(0.0f)),
-            read_number(asset["metallic_factor"], 1.0f),
-            read_number(asset["roughness_factor"], 1.0f),
-            read_number(asset["occlusion_strength"], 1.0f),
-            read_number(asset["normal_scale"], 1.0f),
-            read_number(asset["bloom_intensity"], 0.0f)
-        );
-        break;
-      }
-      case ResourceType::Shader: {
-        auto vertex = parse_path(asset["vertex"]);
-        auto fragment = parse_path(asset["fragment"]);
-        auto geometry = parse_path(asset["geometry"]);
-
-        Shader::create(id, fragment, vertex, geometry);
-
-        break;
-      }
-      case ResourceType::Model: {
-        auto path = parse_path(asset["path"]);
-
-        ASTRA_ENSURE(path == nullptr, "Model path is required");
-
-        Model::create(id, path);
-        break;
-      }
-      case ResourceType::Svg: {
-        auto path = parse_path(asset["path"]);
-
-        ASTRA_ENSURE(path == nullptr, "SVG path is required");
-
-        Svg::create(id, path);
-        break;
-      }
-      case ResourceType::AudioClip: {
-        auto path = parse_path(asset["path"]);
-
-        ASTRA_ENSURE(path == nullptr, "AudioClip path is required");
-
-        AudioClip::create(id, path);
-        break;
-      }
-      case ResourceType::TerrainRecipe: {
-        auto path = parse_path(asset["path"]);
-
-        ASTRA_ENSURE(path == nullptr, "TerrainRecipe path is required");
-
-        TerrainRecipe::create(id, path);
-        break;
-      }
-      default:
-        ASTRA_EXCEPTION("Unknown asset type", type_str);
+      ASTRA_ENSURE(
+          config.resources.asset_bindings.back().asset_path.empty(),
+          "Asset binding path is required for ",
+          config.resources.asset_bindings.back().id
+      );
+      continue;
     }
+
+    if (inline_resource) {
+      deserialize_inline_resource(*this, asset);
+      continue;
+    }
+
+    ASTRA_EXCEPTION(
+        "Resource entry must declare either inline fields or an asset binding"
+    );
   }
 
   auto systems_size = ctx["systems"].size();
@@ -532,6 +955,324 @@ void ProjectSerializer::deserialize() {
         }
         render.headless = content["headless"].as<bool>();
         render.window_id = content["window"].as<std::string>();
+        render.render_graph = manifest_render_graph;
+
+        auto ssao = content["ssao"];
+        if (ssao.kind() == SerializationTypeKind::Object &&
+            ssao["full_resolution"].kind() == SerializationTypeKind::Bool) {
+          render.ssao.full_resolution = ssao["full_resolution"].as<bool>();
+        }
+
+        auto ssgi = content["ssgi"];
+        if (ssgi.kind() == SerializationTypeKind::Object) {
+          render.ssgi.enabled =
+              read_bool(ssgi["enabled"], render.ssgi.enabled);
+          render.ssgi.full_resolution = read_bool(
+              ssgi["full_resolution"], render.ssgi.full_resolution
+          );
+          render.ssgi.intensity =
+              read_number(ssgi["intensity"], render.ssgi.intensity);
+          render.ssgi.radius =
+              read_number(ssgi["radius"], render.ssgi.radius);
+          render.ssgi.thickness =
+              read_number(ssgi["thickness"], render.ssgi.thickness);
+          render.ssgi.directions = static_cast<int>(
+              read_number(
+                  ssgi["directions"],
+                  static_cast<float>(render.ssgi.directions)
+              )
+          );
+          render.ssgi.steps_per_direction = static_cast<int>(
+              read_number(
+                  ssgi["steps_per_direction"],
+                  static_cast<float>(render.ssgi.steps_per_direction)
+              )
+          );
+          render.ssgi.max_distance = read_number(
+              ssgi["max_distance"], render.ssgi.max_distance
+          );
+          render.ssgi.temporal =
+              read_bool(ssgi["temporal"], render.ssgi.temporal);
+          render.ssgi.history_weight = read_number(
+              ssgi["history_weight"], render.ssgi.history_weight
+          );
+          render.ssgi.normal_reject_dot = read_number(
+              ssgi["normal_reject_dot"],
+              render.ssgi.normal_reject_dot
+          );
+          render.ssgi.position_reject_distance = read_number(
+              ssgi["position_reject_distance"],
+              render.ssgi.position_reject_distance
+          );
+        }
+
+        auto ssr = content["ssr"];
+        if (ssr.kind() == SerializationTypeKind::Object) {
+          render.ssr.enabled =
+              read_bool(ssr["enabled"], render.ssr.enabled);
+          render.ssr.intensity =
+              read_number(ssr["intensity"], render.ssr.intensity);
+          render.ssr.max_distance =
+              read_number(ssr["max_distance"], render.ssr.max_distance);
+          render.ssr.thickness =
+              read_number(ssr["thickness"], render.ssr.thickness);
+          render.ssr.max_steps = static_cast<int>(
+              read_number(
+                  ssr["max_steps"],
+                  static_cast<float>(render.ssr.max_steps)
+              )
+          );
+          render.ssr.stride =
+              read_number(ssr["stride"], render.ssr.stride);
+          render.ssr.roughness_cutoff =
+              read_number(ssr["roughness_cutoff"], render.ssr.roughness_cutoff);
+        }
+
+        auto volumetric = content["volumetric"];
+        if (volumetric.kind() == SerializationTypeKind::Object) {
+          render.volumetric.enabled =
+              read_bool(volumetric["enabled"], render.volumetric.enabled);
+          render.volumetric.max_steps = static_cast<int>(
+              read_number(
+                  volumetric["max_steps"],
+                  static_cast<float>(render.volumetric.max_steps)
+              )
+          );
+          render.volumetric.density =
+              read_number(volumetric["density"], render.volumetric.density);
+          render.volumetric.scattering =
+              read_number(volumetric["scattering"], render.volumetric.scattering);
+          render.volumetric.max_distance = read_number(
+              volumetric["max_distance"], render.volumetric.max_distance
+          );
+          render.volumetric.intensity =
+              read_number(volumetric["intensity"], render.volumetric.intensity);
+          render.volumetric.fog_base_height = read_number(
+              volumetric["fog_base_height"], render.volumetric.fog_base_height
+          );
+          render.volumetric.height_falloff_rate = read_number(
+              volumetric["height_falloff_rate"],
+              render.volumetric.height_falloff_rate
+          );
+          render.volumetric.noise_scale = read_number(
+              volumetric["noise_scale"], render.volumetric.noise_scale
+          );
+          render.volumetric.noise_weight = read_number(
+              volumetric["noise_weight"], render.volumetric.noise_weight
+          );
+          render.volumetric.wind_speed = read_number(
+              volumetric["wind_speed"], render.volumetric.wind_speed
+          );
+          render.volumetric.temporal =
+              read_bool(volumetric["temporal"], render.volumetric.temporal);
+          render.volumetric.temporal_blend_weight = read_number(
+              volumetric["temporal_blend_weight"],
+              render.volumetric.temporal_blend_weight
+          );
+
+          auto wind = volumetric["wind_direction"];
+          if (wind.kind() == SerializationTypeKind::Array) {
+            render.volumetric.wind_direction = glm::vec3(
+                read_number(wind[0], 1.0f),
+                read_number(wind[1], 0.0f),
+                read_number(wind[2], 0.0f)
+            );
+          }
+        }
+
+        auto lens_flare = content["lens_flare"];
+        if (lens_flare.kind() == SerializationTypeKind::Object) {
+          render.lens_flare.enabled =
+              read_bool(lens_flare["enabled"], render.lens_flare.enabled);
+          render.lens_flare.intensity =
+              read_number(lens_flare["intensity"], render.lens_flare.intensity);
+          render.lens_flare.threshold =
+              read_number(lens_flare["threshold"], render.lens_flare.threshold);
+          render.lens_flare.ghost_count = static_cast<int>(
+              read_number(
+                  lens_flare["ghost_count"],
+                  static_cast<float>(render.lens_flare.ghost_count)
+              )
+          );
+          render.lens_flare.ghost_dispersal = read_number(
+              lens_flare["ghost_dispersal"], render.lens_flare.ghost_dispersal
+          );
+          render.lens_flare.ghost_weight = read_number(
+              lens_flare["ghost_weight"], render.lens_flare.ghost_weight
+          );
+          render.lens_flare.halo_radius = read_number(
+              lens_flare["halo_radius"], render.lens_flare.halo_radius
+          );
+          render.lens_flare.halo_weight = read_number(
+              lens_flare["halo_weight"], render.lens_flare.halo_weight
+          );
+          render.lens_flare.halo_thickness = read_number(
+              lens_flare["halo_thickness"], render.lens_flare.halo_thickness
+          );
+          render.lens_flare.chromatic_aberration = read_number(
+              lens_flare["chromatic_aberration"],
+              render.lens_flare.chromatic_aberration
+          );
+        }
+
+        auto eye_adaptation = content["eye_adaptation"];
+        if (eye_adaptation.kind() == SerializationTypeKind::Object) {
+          render.eye_adaptation.enabled = read_bool(
+              eye_adaptation["enabled"], render.eye_adaptation.enabled
+          );
+          render.eye_adaptation.min_log_luminance = read_number(
+              eye_adaptation["min_log_luminance"],
+              render.eye_adaptation.min_log_luminance
+          );
+          render.eye_adaptation.max_log_luminance = read_number(
+              eye_adaptation["max_log_luminance"],
+              render.eye_adaptation.max_log_luminance
+          );
+          render.eye_adaptation.adaptation_speed_up = read_number(
+              eye_adaptation["adaptation_speed_up"],
+              render.eye_adaptation.adaptation_speed_up
+          );
+          render.eye_adaptation.adaptation_speed_down = read_number(
+              eye_adaptation["adaptation_speed_down"],
+              render.eye_adaptation.adaptation_speed_down
+          );
+          render.eye_adaptation.key_value = read_number(
+              eye_adaptation["key_value"], render.eye_adaptation.key_value
+          );
+          render.eye_adaptation.low_percentile = read_number(
+              eye_adaptation["low_percentile"],
+              render.eye_adaptation.low_percentile
+          );
+          render.eye_adaptation.high_percentile = read_number(
+              eye_adaptation["high_percentile"],
+              render.eye_adaptation.high_percentile
+          );
+        }
+
+        auto motion_blur = content["motion_blur"];
+        if (motion_blur.kind() == SerializationTypeKind::Object) {
+          render.motion_blur.enabled =
+              read_bool(motion_blur["enabled"], render.motion_blur.enabled);
+          render.motion_blur.intensity = read_number(
+              motion_blur["intensity"], render.motion_blur.intensity
+          );
+          render.motion_blur.max_samples = static_cast<int>(read_number(
+              motion_blur["max_samples"],
+              static_cast<float>(render.motion_blur.max_samples)
+          ));
+          render.motion_blur.depth_threshold = read_number(
+              motion_blur["depth_threshold"],
+              render.motion_blur.depth_threshold
+          );
+        }
+
+        auto chromatic_aberration = content["chromatic_aberration"];
+        if (chromatic_aberration.kind() == SerializationTypeKind::Object) {
+          render.chromatic_aberration.enabled = read_bool(
+              chromatic_aberration["enabled"],
+              render.chromatic_aberration.enabled
+          );
+          render.chromatic_aberration.intensity = read_number(
+              chromatic_aberration["intensity"],
+              render.chromatic_aberration.intensity
+          );
+        }
+
+        auto vignette = content["vignette"];
+        if (vignette.kind() == SerializationTypeKind::Object) {
+          render.vignette.enabled =
+              read_bool(vignette["enabled"], render.vignette.enabled);
+          render.vignette.intensity =
+              read_number(vignette["intensity"], render.vignette.intensity);
+          render.vignette.smoothness =
+              read_number(vignette["smoothness"], render.vignette.smoothness);
+          render.vignette.roundness =
+              read_number(vignette["roundness"], render.vignette.roundness);
+        }
+
+        auto film_grain = content["film_grain"];
+        if (film_grain.kind() == SerializationTypeKind::Object) {
+          render.film_grain.enabled =
+              read_bool(film_grain["enabled"], render.film_grain.enabled);
+          render.film_grain.intensity =
+              read_number(film_grain["intensity"], render.film_grain.intensity);
+        }
+
+        auto depth_of_field = content["depth_of_field"];
+        if (depth_of_field.kind() == SerializationTypeKind::Object) {
+          render.depth_of_field.enabled =
+              read_bool(depth_of_field["enabled"], render.depth_of_field.enabled);
+          render.depth_of_field.focus_distance = read_number(
+              depth_of_field["focus_distance"],
+              render.depth_of_field.focus_distance
+          );
+          render.depth_of_field.focus_range = read_number(
+              depth_of_field["focus_range"],
+              render.depth_of_field.focus_range
+          );
+          render.depth_of_field.max_blur_radius = read_number(
+              depth_of_field["max_blur_radius"],
+              render.depth_of_field.max_blur_radius
+          );
+          render.depth_of_field.sample_count = static_cast<int>(read_number(
+              depth_of_field["sample_count"],
+              static_cast<float>(render.depth_of_field.sample_count)
+          ));
+        }
+
+        auto god_rays = content["god_rays"];
+        if (god_rays.kind() == SerializationTypeKind::Object) {
+          render.god_rays.enabled =
+              read_bool(god_rays["enabled"], render.god_rays.enabled);
+          render.god_rays.intensity =
+              read_number(god_rays["intensity"], render.god_rays.intensity);
+          render.god_rays.decay =
+              read_number(god_rays["decay"], render.god_rays.decay);
+          render.god_rays.density =
+              read_number(god_rays["density"], render.god_rays.density);
+          render.god_rays.weight =
+              read_number(god_rays["weight"], render.god_rays.weight);
+          render.god_rays.threshold =
+              read_number(god_rays["threshold"], render.god_rays.threshold);
+          render.god_rays.samples = static_cast<int>(read_number(
+              god_rays["samples"],
+              static_cast<float>(render.god_rays.samples)
+          ));
+        }
+
+        auto cas = content["cas"];
+        if (cas.kind() == SerializationTypeKind::Object) {
+          render.cas.enabled =
+              read_bool(cas["enabled"], render.cas.enabled);
+          render.cas.sharpness =
+              read_number(cas["sharpness"], render.cas.sharpness);
+          render.cas.contrast =
+              read_number(cas["contrast"], render.cas.contrast);
+          render.cas.sharpening_limit =
+              read_number(cas["sharpening_limit"], render.cas.sharpening_limit);
+        }
+
+        auto taa = content["taa"];
+        if (taa.kind() == SerializationTypeKind::Object) {
+          render.taa.enabled =
+              read_bool(taa["enabled"], render.taa.enabled);
+          render.taa.blend_factor =
+              read_number(taa["blend_factor"], render.taa.blend_factor);
+        }
+
+        auto tonemapping = content["tonemapping"];
+        if (tonemapping.kind() == SerializationTypeKind::Object) {
+          render.tonemapping.tonemap_operator = static_cast<TonemapOperator>(
+              static_cast<int>(read_number(
+                  tonemapping["tonemap_operator"],
+                  static_cast<float>(static_cast<int>(render.tonemapping.tonemap_operator))
+              ))
+          );
+          render.tonemapping.gamma =
+              read_number(tonemapping["gamma"], render.tonemapping.gamma);
+          render.tonemapping.bloom_strength =
+              read_number(tonemapping["bloom_strength"], render.tonemapping.bloom_strength);
+        }
 
         auto msaa = content["msaa"];
 

--- a/src/modules/project/serializers/project-serializer.hpp
+++ b/src/modules/project/serializers/project-serializer.hpp
@@ -19,11 +19,10 @@ public:
 
   void serialize() override;
   void deserialize() override;
+  Ref<Path> parse_path(ContextProxy ctx);
 
 private:
   Ref<Project> m_project = nullptr;
-
-  Ref<Path> parse_path(ContextProxy ctx);
 };
 
 } // namespace astralix

--- a/src/modules/streams/adapters/file/file-stream-reader.cpp
+++ b/src/modules/streams/adapters/file/file-stream-reader.cpp
@@ -19,9 +19,6 @@ FileStreamReader::FileStreamReader(const std::filesystem::path &path)
   );
 
   m_total_size = static_cast<size_t>(total_size);
-  ASTRA_ENSURE(
-      m_total_size == 0, "Cannot read empty file ", m_path.string()
-  );
 
   m_file.seekg(0, std::ios::beg);
 
@@ -35,6 +32,11 @@ void FileStreamReader::read() {
   ASTRA_ENSURE(
       !m_file.is_open(), "Cannot open file ", m_path.string()
   )
+
+  if (m_total_size == 0u) {
+    m_file.close();
+    return;
+  }
 
   m_file.read(m_buffer->data(), m_buffer->size());
 

--- a/src/modules/streams/stream-buffer.hpp
+++ b/src/modules/streams/stream-buffer.hpp
@@ -11,8 +11,11 @@ namespace astralix {
 
 struct StreamBuffer {
 public:
-  StreamBuffer(size_t capacity) : m_arena(capacity) {
-    m_data = m_arena.allocate(capacity);
+  StreamBuffer(size_t capacity)
+      : m_arena(capacity > 0 ? capacity : 1u), m_size(capacity) {
+    if (capacity > 0) {
+      m_data = m_arena.allocate(capacity);
+    }
   }
 
   ~StreamBuffer() {
@@ -35,15 +38,17 @@ public:
     }
   }
 
-  char *data() { return static_cast<char *>(m_data->data); }
+  char *data() {
+    return m_data != nullptr ? static_cast<char *>(m_data->data) : &m_empty;
+  }
 
-  size_t size() const { return m_data->size; }
+  size_t size() const { return m_data != nullptr ? m_data->size : m_size; }
 
 private:
   ElasticArena m_arena;
-
   ElasticArena::Block *m_data = nullptr;
-  ;
+  size_t m_size = 0u;
+  char m_empty = '\0';
 };
 
 [[nodiscard]] inline Scope<StreamBuffer>

--- a/src/modules/window/events/mouse.hpp
+++ b/src/modules/window/events/mouse.hpp
@@ -36,6 +36,13 @@ public:
     };
   };
 
+  Position wheel_delta() const {
+    return Position{
+        m_wheel_delta.x,
+        m_wheel_delta.y,
+    };
+  }
+
   Position position() const { return m_position; }
 
   void set_position(Position position) {
@@ -64,6 +71,11 @@ public:
     m_changed = true;
   }
 
+  void apply_wheel(Position position) {
+    m_wheel_delta.x += position.x;
+    m_wheel_delta.y += position.y;
+  }
+
   void set_button_state(MouseButton button, bool down);
 
   bool is_button_down(MouseButton button) const;
@@ -72,6 +84,7 @@ public:
 
   void reset_delta() {
     m_delta = {.x = 0, .y = 0};
+    m_wheel_delta = {.x = 0, .y = 0};
     m_changed = false;
 
     for (auto &state : m_button_states) {
@@ -87,6 +100,7 @@ public:
 
 private:
   Position m_delta;
+  Position m_wheel_delta{.x = 0.0, .y = 0.0};
   Position m_position;
   Position m_last;
   ButtonState m_button_states[static_cast<size_t>(MouseButton::Count)];

--- a/src/modules/window/managers/window-manager.hpp
+++ b/src/modules/window/managers/window-manager.hpp
@@ -62,6 +62,10 @@ namespace input {
   return window_manager()->active_window()->mouse()->delta();
 }
 
+[[nodiscard]] static inline const input::Mouse::Position MOUSE_WHEEL_DELTA() {
+  return window_manager()->active_window()->mouse()->wheel_delta();
+}
+
 [[nodiscard]] static inline const input::Mouse::Position CURSOR_POSITION() {
   return window_manager()->active_window()->mouse()->position();
 }

--- a/src/modules/window/window.cpp
+++ b/src/modules/window/window.cpp
@@ -260,6 +260,9 @@ void Window::scroll_callback(GLFWwindow *window, double xoffset,
     mods |= GLFW_MOD_SUPER;
   }
 
+  self->m_mouse->apply_wheel(
+      input::Mouse::Position{.x = xoffset, .y = yoffset}
+  );
   auto event = MouseWheelEvent(
       xoffset, yoffset, self->id(), input::KeyModifiers::from_glfw(mods));
   EventDispatcher::get()->dispatch(&event);

--- a/src/shared/allocators/arena.test.cpp
+++ b/src/shared/allocators/arena.test.cpp
@@ -1,13 +1,13 @@
 #include "arena.hpp"
 #include "exceptions/base-exception.hpp"
-#include "faker-cxx/faker.h"
-#include "log.hpp"
+#include "helpers/random.hpp"
 #include <gtest/gtest.h>
 
 using namespace astralix;
+using namespace astralix::testing;
 
 TEST(ElasticArenaTest, EnsureNoPoolIncreasehenBlockEqualsCapacity) {
-  const auto page_size = faker::number::integer(32, 1024);
+  const auto page_size = random_integer(32, 1024);
   astralix::ElasticArena elastic_arena(page_size);
 
   const auto block_size = page_size;
@@ -23,9 +23,9 @@ TEST(ElasticArenaTest, EnsureNoPoolIncreasehenBlockEqualsCapacity) {
 }
 
 TEST(ElasticArenaTest, EnsurePoolOverflowWhenIncreasedCapacityIsFull) {
-  const auto page_size = faker::number::integer(1, 32);
+  const auto page_size = random_integer(1, 32);
 
-  auto max_capacity_increase = faker::number::integer(1, 12);
+  auto max_capacity_increase = random_integer(1, 12);
 
   astralix::ElasticArena elastic_arena(page_size, max_capacity_increase);
 
@@ -52,9 +52,9 @@ TEST(ElasticArenaTest, EnsurePoolOverflowWhenIncreasedCapacityIsFull) {
 }
 
 TEST(ElasticArenaTest, PoolIncreaseWhenBlockGreatherThanCapacity) {
-  const auto page_size = faker::number::integer(32, 1024);
+  const auto page_size = random_integer(32, 1024);
 
-  auto max_capacity_increase = faker::number::integer(page_size);
+  auto max_capacity_increase = random_integer(1, page_size);
 
   astralix::ElasticArena elastic_arena(page_size, max_capacity_increase);
 
@@ -112,11 +112,11 @@ TEST(ElasticArenaTest, ResetClearsCapacityIncreaseCount) {
 }
 
 TEST(ElasticStackArenaTest, SinglePushPop) {
-  const auto page_size = faker::number::integer(32, 1024);
+  const auto page_size = random_integer(32, 1024);
   astralix::ElasticArena elastic_arena(page_size);
   astralix::ElasticStackArena stack_arena(elastic_arena);
 
-  const auto block_size = faker::number::integer(32, page_size);
+  const auto block_size = random_integer(32, page_size);
 
   // Initial memory should be 0
   EXPECT_EQ(stack_arena.allocated_memory(), 0);
@@ -133,7 +133,7 @@ TEST(ElasticStackArenaTest, SinglePushPop) {
 }
 
 TEST(ElasticStackArenaTest, MultiPushWithLinearPop) {
-  const auto page_size = faker::number::integer(32, 1024);
+  const auto page_size = random_integer(32, 1024);
 
   astralix::ElasticArena elastic_arena(page_size);
 
@@ -144,7 +144,7 @@ TEST(ElasticStackArenaTest, MultiPushWithLinearPop) {
   //
   EXPECT_EQ(stack_arena.allocated_memory(), elastic_arena.allocated_memory());
 
-  const auto block_size = faker::number::integer(32, 1024);
+  const auto block_size = random_integer(32, 1024);
 
   int allocations = 0;
 
@@ -167,10 +167,10 @@ TEST(ElasticStackArenaTest, MultiPushWithLinearPop) {
 }
 
 TEST(ElasticStackArenaTest, MultiplePushWithPartialPop) {
-  const auto page_size = faker::number::integer(32, 1024);
+  const auto page_size = random_integer(32, 1024);
 
-  const auto max_allocations = faker::number::integer(32, page_size);
-  const auto min_allocations = faker::number::integer(32, max_allocations);
+  const auto max_allocations = random_integer(32, page_size);
+  const auto min_allocations = random_integer(32, max_allocations);
 
   astralix::ElasticArena elastic_arena(page_size, max_allocations);
   astralix::ElasticStackArena stack_arena(elastic_arena);
@@ -218,8 +218,8 @@ TEST(ElasticStackArenaTest, ClearReleasesAllBlocks) {
 }
 
 TEST(Str, EnsureEquality) {
-  const auto sso_text_length = faker::number::integer(1, 22);
-  const auto sso_text = faker::string::alpha(sso_text_length);
+  const auto sso_text_length = random_integer(1, 22);
+  const auto sso_text = random_alpha(sso_text_length);
 
   auto arena = ElasticArena(KB(1));
 
@@ -235,7 +235,7 @@ TEST(Str, EnsureEquality) {
   EXPECT_EQ(sso_str.size(), 0);
   EXPECT_EQ(sso_str.allocated_memory(), 0);
 
-  const auto text = faker::lorem::sentences();
+  const auto text = random_sentences();
 
   Str str = Str::from_initializer({arena, text.c_str()});
 
@@ -244,8 +244,8 @@ TEST(Str, EnsureEquality) {
 }
 
 TEST(Str, SmallStringShouldHitSSO) {
-  const auto sso_text_length = faker::number::integer(1, 22);
-  const auto text = faker::string::alpha(sso_text_length);
+  const auto sso_text_length = random_integer(1, 22);
+  const auto text = random_alpha(sso_text_length);
 
   auto arena = ElasticArena(KB(1));
 
@@ -258,7 +258,7 @@ TEST(Str, SmallStringShouldHitSSO) {
 }
 
 TEST(Str, LargeStringShouldNotHitSSO) {
-  const auto text = faker::lorem::sentences();
+  const auto text = random_sentences();
 
   auto arena = ElasticArena(KB(1));
 
@@ -271,8 +271,8 @@ TEST(Str, LargeStringShouldNotHitSSO) {
 }
 
 TEST(Str, AppendWithSmallStringShouldHitSSO) {
-  const auto sso_text_length = faker::number::integer(1, 22);
-  const auto text = faker::string::alpha(sso_text_length);
+  const auto sso_text_length = random_integer(1, 22);
+  const auto text = random_alpha(sso_text_length);
 
   auto arena = ElasticArena(KB(1));
   Str str = Str::from_initializer({arena, text.c_str()});
@@ -282,7 +282,7 @@ TEST(Str, AppendWithSmallStringShouldHitSSO) {
   EXPECT_TRUE(str.is_sso());
   EXPECT_EQ(other.size(), 0);
 
-  const auto sub_length = faker::number::integer(1, sso_text_length);
+  const auto sub_length = random_integer(1, sso_text_length);
   other.append(str, sub_length);
 
   EXPECT_EQ(other.size(), sub_length);
@@ -303,7 +303,7 @@ TEST(Str, AppendWithSmallStringShouldHitSSO) {
 }
 
 TEST(Str, AppendWithLargeStringShouldNotHitSSO) {
-  const auto text = faker::lorem::sentences();
+  const auto text = random_sentences();
 
   auto arena = ElasticArena(KB(1));
 
@@ -314,7 +314,7 @@ TEST(Str, AppendWithLargeStringShouldNotHitSSO) {
   EXPECT_FALSE(str.is_sso());
   EXPECT_EQ(other.size(), 0);
 
-  const auto sub_length = faker::number::integer(23, (int)text.size());
+  const auto sub_length = random_integer(23, (int)text.size());
   other.append(str, sub_length);
 
   EXPECT_EQ(other.size(), sub_length);
@@ -337,7 +337,7 @@ TEST(Str, AppendWithLargeStringShouldNotHitSSO) {
 }
 
 TEST(Str, AppendCStr) {
-  const auto text = faker::lorem::sentences();
+  const auto text = random_sentences();
 
   auto arena = ElasticArena(KB(1));
 
@@ -347,7 +347,7 @@ TEST(Str, AppendCStr) {
   EXPECT_FALSE(str.is_sso());
   EXPECT_EQ(other.size(), 0);
 
-  const auto sub_length = faker::number::integer(23, (int)text.size());
+  const auto sub_length = random_integer(23, (int)text.size());
   other.append(str.c_str(), sub_length);
 
   EXPECT_EQ(other.size(), sub_length);
@@ -374,7 +374,7 @@ TEST(Str, AppendLargeStringToEmptyStr) {
 
   Str empty_str(arena);
 
-  const auto large_text = faker::lorem::sentences();
+  const auto large_text = random_sentences();
   empty_str.append(large_text.c_str(), large_text.size());
 
   EXPECT_FALSE(empty_str.is_sso());
@@ -390,7 +390,7 @@ TEST(Str, EmptyStringAppend) {
   EXPECT_EQ(str.size(), 0);
   EXPECT_STREQ(str.c_str(), "");
 
-  const auto text = faker::string::alpha(10);
+  const auto text = random_alpha(10);
   str.append(text.c_str(), text.size());
   EXPECT_TRUE(str.is_sso());
   EXPECT_EQ(str, text);
@@ -399,8 +399,8 @@ TEST(Str, EmptyStringAppend) {
 TEST(Str, AppendSmallToSmallWithinSSO) {
   auto arena = ElasticArena(KB(1));
 
-  const auto str_text = faker::string::alpha(10);
-  const auto other_text = faker::string::alpha(10); // 10 + 10 = 20 <= 22
+  const auto str_text = random_alpha(10);
+  const auto other_text = random_alpha(10); // 10 + 10 = 20 <= 22
 
   Str str(str_text.c_str(), arena);
   Str other(other_text.c_str(), arena);
@@ -415,8 +415,8 @@ TEST(Str, AppendSmallToSmallWithinSSO) {
 TEST(Str, AppendSmallToSmallExceedingSSO) {
   auto arena = ElasticArena(KB(1));
 
-  const auto str_text = faker::string::alpha(15);
-  const auto other_text = faker::string::alpha(10); // 15 + 10 = 25 > 22
+  const auto str_text = random_alpha(15);
+  const auto other_text = random_alpha(10); // 15 + 10 = 25 > 22
 
   Str str(str_text.c_str(), arena);
   Str other(other_text.c_str(), arena);
@@ -431,12 +431,12 @@ TEST(Str, AppendSmallToSmallExceedingSSO) {
 TEST(Str, NullTermination) {
   auto arena = ElasticArena(KB(1));
 
-  const auto small_text = faker::string::alpha(10);
+  const auto small_text = random_alpha(10);
   Str small_str(small_text.c_str(), arena);
   EXPECT_EQ(std::strlen(small_str.c_str()), small_text.size());
   EXPECT_EQ(small_str.c_str()[small_text.size()], '\0');
 
-  const auto large_text = faker::lorem::sentences();
+  const auto large_text = random_sentences();
   Str large_str(large_text.c_str(), arena);
   EXPECT_EQ(std::strlen(large_str.c_str()), large_text.size());
   EXPECT_EQ(large_str.c_str()[large_text.size()], '\0');
@@ -445,8 +445,8 @@ TEST(Str, NullTermination) {
 TEST(Str, AppendLargeToSmall) {
   auto arena = ElasticArena(KB(1));
 
-  const auto small_text = faker::string::alpha(10);
-  const auto large_text = faker::lorem::sentences();
+  const auto small_text = random_alpha(10);
+  const auto large_text = random_sentences();
 
   Str small_str(small_text.c_str(), arena);
   Str large_str(large_text.c_str(), arena);
@@ -460,8 +460,8 @@ TEST(Str, AppendLargeToSmall) {
 TEST(Str, AppendSmallToLarge) {
   auto arena = ElasticArena(KB(1));
 
-  const auto large_text = faker::lorem::sentences();
-  const auto small_text = faker::string::alpha(10);
+  const auto large_text = random_sentences();
+  const auto small_text = random_alpha(10);
 
   Str large_str(large_text.c_str(), arena);
   Str small_str(small_text.c_str(), arena);
@@ -475,8 +475,8 @@ TEST(Str, AppendSmallToLarge) {
 TEST(Str, AppendLargeToLarge) {
   auto arena = ElasticArena(KB(1));
 
-  const auto str_text = faker::lorem::sentences();
-  const auto other_text = faker::lorem::sentences();
+  const auto str_text = random_sentences();
+  const auto other_text = random_sentences();
 
   Str str(str_text.c_str(), arena);
   Str other(other_text.c_str(), arena);
@@ -491,8 +491,8 @@ TEST(Str, AppendLargeToLarge) {
 TEST(Str, OperatorPlusEqualStr) {
   auto arena = ElasticArena(KB(1));
 
-  const auto str_text = faker::string::alpha(10);
-  const auto other_text = faker::string::alpha(10); // 10 + 10 = 20 <= 22
+  const auto str_text = random_alpha(10);
+  const auto other_text = random_alpha(10); // 10 + 10 = 20 <= 22
 
   Str str(str_text.c_str(), arena);
   Str other(other_text.c_str(), arena);
@@ -507,8 +507,8 @@ TEST(Str, OperatorPlusEqualStr) {
 TEST(Str, OperatorPlusEqualCStr) {
   auto arena = ElasticArena(KB(1));
 
-  const auto str_text = faker::string::alpha(10);
-  const auto other_text = faker::string::alpha(10);
+  const auto str_text = random_alpha(10);
+  const auto other_text = random_alpha(10);
 
   Str str(str_text.c_str(), arena);
   str += other_text.c_str();
@@ -521,7 +521,7 @@ TEST(Str, OperatorPlusEqualCStr) {
 TEST(Str, AssignmentWithCStr) {
   auto arena = ElasticArena(KB(1));
 
-  const auto text = faker::lorem::sentences();
+  const auto text = random_sentences();
 
   Str str(arena);
   str = text.c_str();
@@ -536,7 +536,7 @@ TEST(Str, AssignmentWithCStr) {
 TEST(Str, ReleaseSSOString) {
   auto arena = ElasticArena(KB(1));
 
-  const auto text = faker::string::alpha(10);
+  const auto text = random_alpha(10);
 
   Str str(text.c_str(), arena);
 
@@ -550,7 +550,7 @@ TEST(Str, ReleaseSSOString) {
 TEST(Str, ReleaseNonSSOString) {
   auto arena = ElasticArena(KB(1));
 
-  const auto text = faker::lorem::sentences();
+  const auto text = random_sentences();
   Str str(text.c_str(), arena);
   EXPECT_FALSE(str.is_sso());
   str.release();
@@ -561,7 +561,7 @@ TEST(Str, ReleaseNonSSOString) {
 TEST(Str, SelfAppend) {
   auto arena = ElasticArena(KB(1));
 
-  const auto text = faker::string::alpha(10);
+  const auto text = random_alpha(10);
   Str str(text.c_str(), arena);
   str.append(str, str.size());
 

--- a/src/shared/ecs/managers/system-manager.cpp
+++ b/src/shared/ecs/managers/system-manager.cpp
@@ -15,6 +15,9 @@ void SystemManager::start() {
   ASTRA_PROFILE_N("SystemManager::start");
   for (ISystem_ptr system : m_system_work_order) {
     if (system->m_enabled) {
+      ASTRA_PROFILE_N("System::start");
+      const char *name = system->get_system_type_name();
+      ASTRA_PROFILE_TEXT(name, strlen(name));
       system->start();
     }
   }

--- a/src/shared/ecs/managers/system-manager.hpp
+++ b/src/shared/ecs/managers/system-manager.hpp
@@ -9,6 +9,7 @@
 #include "systems/isystem.hpp"
 #include "unordered_map"
 #include "vector"
+#include <algorithm>
 #include <vector>
 
 namespace astralix {
@@ -93,6 +94,39 @@ public:
     }
 
     this->add_system_dependency(target, std::forward<Dependencies>(dependencies)...);
+  }
+
+  template <class T>
+  void remove_system() {
+    const SystemTypeID type_id = T::system_type_id();
+    auto it = m_system_table.find(type_id);
+    if (it == m_system_table.end()) return;
+
+    it->second->end();
+
+    std::erase_if(m_system_work_order,
+      [type_id](const ISystem_ptr& system) {
+        return system->get_system_type_id() == type_id;
+      });
+
+    if (type_id < m_system_dependency_table.size()) {
+      for (auto& row : m_system_dependency_table) {
+        if (type_id < row.size()) row[type_id] = false;
+      }
+      std::fill(m_system_dependency_table[type_id].begin(),
+                m_system_dependency_table[type_id].end(), false);
+    }
+
+    m_system_table.erase(it);
+    update_system_work_order();
+  }
+
+  template <class T>
+  void start_system() {
+    auto it = m_system_table.find(T::system_type_id());
+    if (it != m_system_table.end()) {
+      it->second->start();
+    }
   }
 
   void update_system_work_order();

--- a/src/shared/ecs/systems/isystem.hpp
+++ b/src/shared/ecs/systems/isystem.hpp
@@ -36,6 +36,7 @@ public:
   virtual inline const char *get_system_type_name() const = 0;
 
   virtual void start() = 0;
+  virtual void end() {}
   virtual void fixed_update(double fixed_dt) = 0;
   virtual void pre_update(double dt) = 0;
   virtual void update(double dt) = 0;

--- a/src/shared/foundation/assert.hpp
+++ b/src/shared/foundation/assert.hpp
@@ -76,6 +76,10 @@ static size_t levenshtein_distance(const std::string &str_value,
   throw BaseException(__FILE__, __FUNCTION__, __LINE__,                        \
                       build_exception_message(__VA_ARGS__));
 
+#define ASTRA_EXCEPTION_META(metadata, ...)                                    \
+  throw BaseException(__FILE__, __FUNCTION__, __LINE__,                        \
+                      build_exception_message(__VA_ARGS__), metadata);
+
 #define ASTRA_ENSURE(EXPRESSION, ...)                                          \
   if (EXPRESSION) {                                                            \
     throw BaseException(__FILE__, __FUNCTION__, __LINE__,                      \

--- a/src/shared/foundation/exceptions/base-exception.cpp
+++ b/src/shared/foundation/exceptions/base-exception.cpp
@@ -6,13 +6,32 @@ namespace astralix {
 
 BaseException::BaseException(const char *file, const char *function, int line,
                              std::string message)
-    : m_line(line), m_file(file), m_function(function), m_message(message) {
+    : m_line(line), m_file(file), m_function(function), m_message(std::move(message)) {
+  format();
+}
+
+BaseException::BaseException(const char *file, const char *function, int line,
+                             std::string message, ExceptionMetadata metadata)
+    : m_line(line), m_file(file), m_function(function),
+      m_message(std::move(message)), m_metadata(std::move(metadata)) {
+  format();
+}
+
+void BaseException::format() {
   std::ostringstream oss;
   oss << BOLD << RED << "\n=== Astralix Exception ===" << RESET << "\n\n"
       << BOLD << CYAN << "File: " << RESET << m_file << "\n"
       << BOLD << CYAN << "Method: " << RESET << m_function << "\n"
-      << BOLD << CYAN << "Line: " << RESET << m_line << "\n\n"
-      << BOLD << YELLOW << "Message: " << RESET << m_message << "\n\n"
+      << BOLD << CYAN << "Line: " << RESET << m_line << "\n";
+
+  if (!m_metadata.empty()) {
+    oss << "\n" << BOLD << MAGENTA << "Metadata:" << RESET << "\n";
+    for (const auto &[key, value] : m_metadata) {
+      oss << "  " << BOLD << CYAN << key << ": " << RESET << value << "\n";
+    }
+  }
+
+  oss << "\n" << BOLD << YELLOW << "Message: " << RESET << m_message << "\n\n"
       << BOLD << RED << "==========================" << RESET;
   m_formatted_message = oss.str();
 }

--- a/src/shared/foundation/exceptions/base-exception.hpp
+++ b/src/shared/foundation/exceptions/base-exception.hpp
@@ -2,13 +2,20 @@
 #include "exception"
 #include "string"
 #include <sstream>
+#include <vector>
+#include <utility>
 
 namespace astralix {
+
+using ExceptionMetadata = std::vector<std::pair<std::string, std::string>>;
 
 class BaseException : public std::exception {
 public:
   BaseException(const char *file, const char *function, int line,
                 std::string message);
+
+  BaseException(const char *file, const char *function, int line,
+                std::string message, ExceptionMetadata metadata);
 
   const char *what() const noexcept override {
     return m_formatted_message.c_str();
@@ -17,12 +24,16 @@ public:
   const char *file() const noexcept { return m_file; }
   const char *function() const noexcept { return m_function; }
   int line() const noexcept { return m_line; }
+  const ExceptionMetadata &metadata() const noexcept { return m_metadata; }
 
 private:
+  void format();
+
   std::string m_message;
   int m_line;
   const char *m_file;
   const char *m_function;
+  ExceptionMetadata m_metadata;
 
   std::string m_formatted_message;
 };

--- a/src/shared/foundation/log.hpp
+++ b/src/shared/foundation/log.hpp
@@ -11,6 +11,7 @@
 #define RESET "\033[0m"
 #define RED "\033[31m"
 #define YELLOW "\033[33m"
+#define MAGENTA "\033[35m"
 #define CYAN "\033[36m"
 #define BOLD "\033[1m"
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -16,18 +16,13 @@ set(SHARED_DIR "${CMAKE_SOURCE_DIR}/../src/shared")
 set(AXSLC_DIR "${CMAKE_SOURCE_DIR}/../axslc")
 set(AXGEN_DIR "${CMAKE_SOURCE_DIR}/../axgen")
 set(AXGEN_SRC_DIR "${AXGEN_DIR}/src")
-set(FAKER_CXX_DIR "${CMAKE_SOURCE_DIR}/../external/faker-cxx")
-set(GOOGLETEST_DIR "${FAKER_CXX_DIR}/externals/googletest")
+set(GTest_DIR "${VCPKG_INSTALLED_ROOT}/share/gtest")
 
 include("${MODULES_DIR}/streams/serialization-formats.cmake")
 
 set(ASTRALIX_TEST_SERIALIZATION_FORMATS Json Yaml Toml Xml)
 
-set(BUILD_TESTING OFF CACHE BOOL "" FORCE)
-add_subdirectory("${FAKER_CXX_DIR}" "${CMAKE_CURRENT_BINARY_DIR}/faker-cxx"
-                 EXCLUDE_FROM_ALL)
-add_subdirectory("${GOOGLETEST_DIR}" "${CMAKE_CURRENT_BINARY_DIR}/googletest"
-                 EXCLUDE_FROM_ALL)
+find_package(GTest CONFIG REQUIRED)
 find_package(glad CONFIG REQUIRED)
 find_package(unofficial-shaderc CONFIG REQUIRED)
 
@@ -77,6 +72,7 @@ add_executable(astralix_tests
   ${SERIALIZATION_SRC})
 
 target_include_directories(astralix_tests PRIVATE
+  "${CMAKE_SOURCE_DIR}"
   "${CMAKE_SOURCE_DIR}/../src/modules/renderer"
   "${CMAKE_SOURCE_DIR}/../src/shared"
   "${CMAKE_SOURCE_DIR}/../src/assets/.astralix/generated"
@@ -97,9 +93,8 @@ target_include_directories(astralix_tests PRIVATE
   "${AXGEN_SRC_DIR}")
 
 target_link_libraries(astralix_tests PRIVATE
-  faker-cxx
-  gtest
-  gtest_main
+  GTest::gtest
+  GTest::gtest_main
   glad::glad)
 
 target_compile_definitions(astralix_tests PRIVATE

--- a/tests/helpers/random.hpp
+++ b/tests/helpers/random.hpp
@@ -1,0 +1,52 @@
+#pragma once
+
+#include <random>
+#include <string>
+
+namespace astralix::testing {
+
+inline std::mt19937 &rng() {
+  static std::mt19937 generator{std::random_device{}()};
+  return generator;
+}
+
+inline int random_integer(int min, int max) {
+  std::uniform_int_distribution<int> distribution(min, max);
+  return distribution(rng());
+}
+
+inline std::string random_alpha(int length) {
+  static constexpr char alphabet[] =
+      "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ";
+  std::uniform_int_distribution<int> distribution(0, sizeof(alphabet) - 2);
+  std::string result;
+  result.reserve(static_cast<std::string::size_type>(length));
+  for (int i = 0; i < length; ++i)
+    result += alphabet[distribution(rng())];
+  return result;
+}
+
+inline std::string random_sentences() {
+  static constexpr const char *words[] = {
+      "lorem",      "ipsum",   "dolor",    "sit",       "amet",
+      "consectetur","adipiscing","elit",    "sed",       "do",
+      "eiusmod",    "tempor",  "incididunt","ut",       "labore",
+      "et",         "dolore",  "magna",    "aliqua",    "fusce",
+      "posuere",    "morbi",   "tempus",   "iaculis",   "urna",
+      "id",         "volutpat","lacus",    "laoreet",   "non",
+      "curabitur",  "gravida", "arcu",     "ac",        "tortor",
+      "dignissim"};
+  int word_count = random_integer(30, 60);
+  std::uniform_int_distribution<int> distribution(
+      0, sizeof(words) / sizeof(words[0]) - 1);
+  std::string result;
+  for (int i = 0; i < word_count; ++i) {
+    if (i > 0)
+      result += ' ';
+    result += words[distribution(rng())];
+  }
+  result += '.';
+  return result;
+}
+
+} // namespace astralix::testing


### PR DESCRIPTION
## Summary
- Add SSGI, volumetric fog, lens flare, SSR, eye adaptation, motion blur, and other post-processing config structs to project manifest
- Add render graph resource/pass configuration DSL with `on_manifest_reload` callback
- Add asset registry with cook pipeline, dependency graph, file watcher, and pack manifest
- Add `cook` command and serializer tests to axgen CLI
- Extend stream buffer for asset I/O